### PR TITLE
Generic maws role module

### DIFF
--- a/aws/maws-roles/README.md
+++ b/aws/maws-roles/README.md
@@ -1,0 +1,52 @@
+# maws-roles
+This creates roles that we can assume into using an OIDC provider
+
+## Usage
+
+If you know the policy ARN of a pre-existing policy that AWS has you can just reference it
+
+```
+module "admin_role" {
+  source     = "github.com/mozila-it/terraform-modules//aws/maws-roles?ref=master"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+```
+
+If you want to create a specific role with specific permission you will need to create
+the policy first and then attach it to the module
+
+```
+data "aws_iam_policy_document" "example" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "test_policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.example.json
+}
+
+module "role" {
+  source     = "github.com/mozila-it/terraform-modules//aws/maws-roles?ref=master"
+  policy_arn = aws_iam_policy.policy.arn
+}
+```
+
+## Inputs
+
+| Input                   | Description                                                       |
+|-------------------------|-------------------------------------------------------------------|
+| `idp_client_id`         | This is the client_id of the auth0 idp, an optional value         |
+| `max_session_duration`  | Max session time before your session exires (Default: 43200       |
+| `policy_arn`            | The mozillians or ldap group you want to grant access to the role |

--- a/aws/maws-roles/main.tf
+++ b/aws/maws-roles/main.tf
@@ -1,0 +1,55 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/auth.mozilla.auth0.com/"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "auth.mozilla.auth0.com/:aud"
+      values = [
+        var.idp_client_id
+      ]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "auth.mozilla.auth0.com/:amr"
+      values   = var.role_mapping
+    }
+  }
+}
+
+locals {
+  default_tags = {
+    Service   = "MAWS"
+    Terraform = "true"
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name                 = var.role_name
+  description          = "MAWS role for ${var.role_name}, managed by terraform"
+  max_session_duration = var.max_session_duration
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+
+  tags = merge(
+    {
+      "Name" = var.role_name
+    },
+    local.default_tags
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.policy_arn
+}

--- a/aws/maws-roles/outputs.tf
+++ b/aws/maws-roles/outputs.tf
@@ -1,0 +1,9 @@
+
+
+output "role_id" {
+  value = aws_iam_role.this.id
+}
+
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}

--- a/aws/maws-roles/variables.tf
+++ b/aws/maws-roles/variables.tf
@@ -1,0 +1,16 @@
+
+variable "idp_client_id" {
+  default = "N7lULzWtfVUDGymwDs0yDEq6ZcwmFazj" #pragma: allowlist secret
+}
+
+
+variable "max_session_duration" {
+  default = "43200" # 12 hours
+}
+
+variable "role_mapping" {
+  type        = list(string)
+  description = "The Mozilla LDAP or Mozillians group name to grant access to the roles"
+}
+
+variable "policy_arn" {}


### PR DESCRIPTION
This is an intial commit of the maws-roles module. This allows a
generic method of creating roles and granting access via maws