### PR TITLE
Create EKS terraform module

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -1,6 +1,6 @@
 # teraform-eks
-This is an opinionated way of getting setting up an EKS cluster using terraform. This module installs several helm packages
-by default and the packages are:
+This is an opinionated way of setting up an EKS cluster using terraform. This module installs several helm packages
+by default, packages installed listed below:
 
  - `aws-node-termination-handler` - Drains node when a node is terminated
  - `metrics-server` - metrics server we all know and love

--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -1,0 +1,112 @@
+# teraform-eks
+This is an opinionated way of getting setting up an EKS cluster using terraform. This module installs several helm packages
+by default and the packages are:
+
+ - `aws-node-termination-handler` - Drains node when a node is terminated
+ - `metrics-server` - metrics server we all know and love
+ - `cluster-autoscaler` - Cluster autoscaler
+ - `reloader` - Reloads a deployment when you update a configmap or secret
+ - `helm-operator` - This is an optional package and installs the flux helm operator
+
+## Usage
+Example usage:
+
+```bash
+locals {
+  cluster_name    = "my-cluster"
+  cluster_version = "1.15"
+
+  map_roles = [
+    {
+      username = "itsre-admin"
+      rolearn  = "arn:aws:iam::178589013767:role/itsre-admin"
+      groups   = ["system:masters"]
+    },
+	{
+	  username = "maws-admin"
+      rolearn  = "arn:aws:iam::517826968395:role/maws-admin"
+      groups   = ["system:masters"]
+	}
+  ]
+
+  node_groups = {
+    node-group-1 = {
+      desired_capacity = 2
+      max_capactiy     = 5
+      min_capacity     = 2
+      instance_type    = "t3.small"
+	  subnets          = data.terraform_remote_state.vpc.outputs.private_subnets
+
+      k8s_labels = {
+        Environment = "test"
+        Node        = "managed"
+      }
+
+      additional_tags = {
+        "kubernetes.io/cluster/${local.cluster_name}" = "owned"
+        "k8s.io/cluster-autoscaler/enabled"           = "true"
+      }
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# Every account that has a vpc deployed should have
+# a vpc id and subnets outputed somewhere to a remote state
+# so we are just grabbing the subnet id's and vpc id
+data terraform_remote_state "vpc" {
+  backend = "s3"
+
+  config = {
+    bucket         = "itsre-state-517826968395"
+    key            = "terraform/deploy.tfstate"
+    dynamodb_table = "itsre-state-517826968395"
+    region         = "eu-west-1"
+  }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "eks" {
+  source          = "github.com/mozilla-it/terraform-modules//aws/eks?ref=master"
+  cluster_name    = local.cluster_name
+  cluster_version = local.cluster_version
+  vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
+  cluster_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
+  node_groups     = local.node_groups
+}
+
+```
+
+## Inputs
+
+| Name              | Description                                                                                          | Default      |
+|-------------------|------------------------------------------------------------------------------------------------------|--------------|
+| `region`          | Region to deploy EKS cluster to                                                                      | `us-west-2`  |
+| `cluster_name`    | Name of cluster identifier (This is required)                                                        | `n/a`        |
+| `cluster_version` | Kubernetes version                                                                                   | `1.14`       |
+| `vpc_id`          | VPC ID to deploy EKS to                                                                              | `n/a`        |
+| `cluster_subnets` | A list of subnets to place the EKS cluster and workers within.                                       | `n/a         |
+| `map_roles`       | Additional IAM roles to add to the aws-auth configmap                                                | `[]`         |
+| `map_users`       | Additional IAM users to add to the aws-auth configmap                                                | `[]`         |
+| `map_accounts`    | Additional AWS account numbers to add to the aws-auth configmap                                      | `[]`         |
+| `node_groups`     | Map of map of node groups to create                                                                  | `{}`         |
+| `worker_groups`   | A list of maps defining worker group configurations to be defined using AWS Launch Configurations.   | `{}`         |
+| `enable_flux`     | Enable or disable flux helm operator                                                                 | `false`      |
+| `enable_logging`  | Enable kubernetes cluster logging                                                                    | `false`      |
+| `log_retention`   | Number of days to retain log events                                                                  | `30`         |
+| `tags`            | A map of tags to add to all resources.                                                               | `{}`         |
+
+## Other documentation
+
+* [terraform-aws-eks-modules](https://github.com/terraform-aws-modules/terraform-aws-eks/)
+* [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+* [Terraform Helm](https://www.terraform.io/docs/providers/helm/r/release.html)
+* [Node groups accepted values](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/node_groups/README.md)

--- a/aws/eks/autoscaler.tf
+++ b/aws/eks/autoscaler.tf
@@ -1,0 +1,58 @@
+
+module "cluster_autoscaler_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> v2.6.0"
+  create_role                   = true
+  role_name                     = local.cluster_autoscaler_name_prefix
+  provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+  role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name_prefix = local.cluster_autoscaler_name_prefix
+  description = "EKS cluster-autoscaler policy for cluster ${module.eks.cluster_id}"
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "clusterAutoscalerAll"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "clusterAutoscalerOwn"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
+      values   = ["true"]
+    }
+  }
+}

--- a/aws/eks/data.tf
+++ b/aws/eks/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -1,0 +1,102 @@
+provider "helm" {
+  version = "~> 1"
+
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    load_config_file       = false
+  }
+}
+
+data "helm_repository" "eks" {
+  name = "eks"
+  url  = "https://aws.github.io/eks-charts"
+}
+
+data "helm_repository" "fluxcd" {
+  count = var.enable_flux ? 1 : 0
+  name  = "fluxcd"
+  url   = "https://charts.fluxcd.io"
+}
+
+data "helm_repository" "stable" {
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
+}
+
+resource "helm_release" "node_drain" {
+  name       = "aws-node-termination-handler"
+  repository = data.helm_repository.eks.metadata.0.name
+  chart      = "eks/aws-node-termination-handler"
+  namespace  = "kube-system"
+
+  depends_on = [module.eks]
+}
+
+resource "helm_release" "metrics_server" {
+  name       = "metrics-server"
+  repository = data.helm_repository.stable.metadata.0.name
+  chart      = "stable/metrics-server"
+  namespace  = "kube-system"
+
+  depends_on = [module.eks]
+}
+
+resource "helm_release" "cluster_autoscaler" {
+  name       = "cluster-autoscaler"
+  repository = data.helm_repository.stable.metadata.0.name
+  chart      = "stable/cluster-autoscaler"
+  namespace  = "kube-system"
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.cluster_autoscaler_settings
+
+    content {
+      name  = item.value.name
+      value = item.value.value
+    }
+  }
+
+  depends_on = [module.eks]
+}
+
+resource "helm_release" "reloader" {
+  name       = "reloader"
+  repository = data.helm_repository.stable.metadata.0.name
+  chart      = "stable/reloader"
+  namespace  = "kube-system"
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.reloader_settings
+
+    content {
+      name  = item.value.name
+      value = item.value.value
+    }
+  }
+
+  depends_on = [module.eks]
+}
+
+resource "helm_release" "flux_helm_operator" {
+  count      = var.enable_flux ? 1 : 0
+  name       = "helm-operator"
+  repository = data.helm_repository.fluxcd.0.name
+  chart      = "fluxcd/helm-operator"
+  namespace  = "flux"
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.flux_helm_operator_settings
+
+    content {
+      name  = item.value.name
+      value = item.value.value
+    }
+  }
+
+  depends_on = [module.eks]
+}

--- a/aws/eks/k8s.tf
+++ b/aws/eks/k8s.tf
@@ -1,0 +1,7 @@
+
+resource "kubernetes_namespace" "flux" {
+  count = var.enable_flux ? 1 : 0
+  metadata {
+    name = "flux"
+  }
+}

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -1,0 +1,96 @@
+locals {
+
+  tags = merge(
+    {
+      "Region"    = var.region
+      "Terraform" = "true"
+    },
+    var.tags,
+  )
+
+  cluster_log_type = var.enable_logging ? ["api", "audit", "authenticator", "controllerManager", "scheduler"] : []
+
+  cluster_autoscaler_name_prefix               = "${module.eks.cluster_id}-cluster-autoscaler"
+  cluster_autoscaler_service_account_namespace = "kube-system"
+  cluster_autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler"
+
+  # Maps k8s version to an image version
+  cluster_autoscaler_versions = {
+    "1.13" = "v1.13.9"
+    "1.14" = "v1.14.7"
+    # By default this should be 1.15.5 but
+    # they have not released a version in the 1.15.x branch
+    # to accept irsa yet (IAM Roles for Service accounts)
+    # See: https://github.com/kubernetes/autoscaler/issues/2920
+    "1.15" = "v1.14.7"
+    "1.16" = "v1.16.4"
+    "1.17" = "v1.17.1"
+  }
+
+  kube_state_metrics_versions = {
+    "1.13" = "v1.6.0"
+    "1.14" = "v1.7.2"
+    "1.15" = "v1.8.0"
+    "1.16" = "v1.9.5"
+    "1.17" = "master"
+  }
+
+  # TODO: We should set this as a default and create
+  # a variable to configure additional settings to
+  # allow more configurability
+  cluster_autoscaler_settings = [
+    {
+      name  = "awsRegion"
+      value = var.region
+    },
+    {
+      name  = "image.tag"
+      value = lookup(local.cluster_autoscaler_versions, var.cluster_version)
+    },
+    {
+      name  = "autoDiscovery.clusterName"
+      value = module.eks.cluster_id
+    },
+    {
+      name  = "autoDiscovery.enabled"
+      value = "true"
+    },
+    {
+      name  = "rbac.create"
+      value = "true"
+    },
+    {
+      # Double slash needed to escape dots
+      name  = "rbac.serviceAccountAnnotations.eks\\.amazonaws\\.com/role-arn"
+      value = module.cluster_autoscaler_role.this_iam_role_arn
+    },
+    # Recommended per aws' recommendation
+    {
+      name  = "extraArgs.skip-nodes-with-system-pods"
+      value = "false"
+    },
+    {
+      name  = "extraArgs.balance-similar-node-groups"
+      value = "true"
+    }
+  ]
+
+  reloader_settings = [
+    {
+      name  = "reloader.deployment.image.tag"
+      value = "v0.0.58"
+    }
+  ]
+
+  flux_helm_operator_settings = [
+    {
+      name  = "createCRD"
+      value = "true"
+    },
+    {
+      name  = "helm.versions"
+      value = "v3"
+    }
+  ]
+
+}

--- a/aws/eks/outputs.tf
+++ b/aws/eks/outputs.tf
@@ -1,0 +1,47 @@
+output "cluster_id" {
+  value = module.eks.cluster_id
+}
+
+output "cluster_version" {
+  value = module.eks.cluster_version
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_arn" {
+  value = module.eks.cluster_arn
+}
+
+output "worker_asg_names" {
+  value = module.eks.workers_asg_names
+}
+
+output "worker_iam_role_arn" {
+  value = module.eks.worker_iam_role_arn
+}
+
+output "worker_security_group_id" {
+  value = module.eks.worker_security_group_id
+}
+
+output "cluster_iam_role_name" {
+  value = module.eks.cluster_iam_role_name
+}
+
+output "cluster_iam_role_arn" {
+  value = module.eks.cluster_iam_role_arn
+}
+
+output "node_groups" {
+  value = module.eks.node_groups
+}
+
+output "cluster_oidc_issuer_url" {
+  value = module.eks.cluster_oidc_issuer_url
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -1,0 +1,49 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "cluster_name" {}
+
+variable "cluster_version" {
+  default = "1.14"
+}
+
+variable "vpc_id" {}
+
+variable "cluster_subnets" {}
+
+variable "tags" {
+  default = {}
+}
+
+variable "map_roles" {
+  default = []
+}
+
+variable "map_users" {
+  default = []
+}
+
+variable "map_accounts" {
+  default = []
+}
+
+variable "node_groups" {
+  default = {}
+}
+
+variable "worker_groups" {
+  default = {}
+}
+
+variable "enable_flux" {
+  default = false
+}
+
+variable "enable_logging" {
+  default = false
+}
+
+variable "log_retention" {
+  default = "30"
+}

--- a/aws/eks/versions.tf
+++ b/aws/eks/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This standardize EKS cluster creation and add several standard packages using
helm. The module utilizes the terraform-modules/terraform-aws-eks
upstream modules but it wraps the module by defaulting several of the
options as well as installing a couple of helm charts.

Once deployed the cluster will install several helm packages that we
usually need to have installed on every EKS cluster.