### PR TITLE
Alberto/elasticsearch

### DIFF
--- a/aws/elasticsearch/README.md
+++ b/aws/elasticsearch/README.md
@@ -1,5 +1,13 @@
 # Terraform module for deploying Elasticsearch clusters in AWS
+
 Usage example:
 ```
-
+module "elasticsearch_cluster" {
+	source                  = "github.com/mozilla-it/terraform-modules//aws/elasticsearch"
+	domain_name             = "my-es-cluster"
+	subnet_ids              = element(module.vpc.private_subnets[0], 0)
+	vpc_id                  = module.vpc.vpc_id
+	ingress_security_groups = "sg-12345"
+	ebs_volume_size         = 35
+}
 ```

--- a/aws/elasticsearch/README.md
+++ b/aws/elasticsearch/README.md
@@ -1,0 +1,5 @@
+# Terraform module for deploying Elasticsearch clusters in AWS
+Usage example:
+```
+
+```

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -30,7 +30,7 @@ resource "aws_elasticsearch_domain" "domain" {
 }
 
 resource "aws_security_group" "domain" {
-  name        = "${var.es_domain_name}-sg"
+  name        = "${var.domain_name}-sg"
   description = "Managed by Terraform"
   vpc_id      = var.vpc_id
 

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -1,0 +1,64 @@
+resource "aws_elasticsearch_domain" "domain" {
+  domain_name           = var.domain_name
+  elasticsearch_version = var.es_version
+
+  cluster_config {
+    instance_type  = var.es_instance_type
+    instance_count = var.es_instance_count
+  }
+
+  vpc_options {
+    subnet_ids = [var.subnet_ids]
+
+    security_group_ids = [aws_security_group.domain.id]
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = var.ebs_volume_size
+  }
+
+  advanced_options = {
+    "rest.action.multi.allow_explicit_index" = "true"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "domain" {
+  name        = "${var.es_domain_name}-sg"
+  description = "Managed by Terraform"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+
+    security_groups = [
+      var.ingress_security_groups,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "domain" {
+  statement {
+    actions   = ["es:*"]
+    resources = ["${aws_elasticsearch_domain.domain.arn}/*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_elasticsearch_domain_policy" "domain" {
+  domain_name = aws_elasticsearch_domain.domain.domain_name
+
+  access_policies = data.aws_iam_policy_document.domain.json
+}

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -30,7 +30,7 @@ resource "aws_elasticsearch_domain" "cluster" {
 }
 
 resource "aws_security_group" "cluster_sg" {
-  name        = "${var.domain_name}-sg"
+  name        = "${var.domain_name}-es-sg"
   description = "Managed by Terraform"
   vpc_id      = var.vpc_id
 

--- a/aws/elasticsearch/main.tf
+++ b/aws/elasticsearch/main.tf
@@ -1,4 +1,4 @@
-resource "aws_elasticsearch_domain" "domain" {
+resource "aws_elasticsearch_domain" "cluster" {
   domain_name           = var.domain_name
   elasticsearch_version = var.es_version
 
@@ -8,9 +8,9 @@ resource "aws_elasticsearch_domain" "domain" {
   }
 
   vpc_options {
-    subnet_ids = [var.subnet_ids]
+    subnet_ids = var.subnet_ids
 
-    security_group_ids = [aws_security_group.domain.id]
+    security_group_ids = [aws_security_group.cluster_sg.id]
   }
 
   ebs_options {
@@ -29,7 +29,7 @@ resource "aws_elasticsearch_domain" "domain" {
   tags = var.tags
 }
 
-resource "aws_security_group" "domain" {
+resource "aws_security_group" "cluster_sg" {
   name        = "${var.domain_name}-sg"
   description = "Managed by Terraform"
   vpc_id      = var.vpc_id
@@ -45,10 +45,10 @@ resource "aws_security_group" "domain" {
   }
 }
 
-data "aws_iam_policy_document" "domain" {
+data "aws_iam_policy_document" "cluster_policy_doc" {
   statement {
     actions   = ["es:*"]
-    resources = ["${aws_elasticsearch_domain.domain.arn}/*"]
+    resources = ["${aws_elasticsearch_domain.cluster.arn}/*"]
 
     principals {
       type        = "*"
@@ -57,8 +57,8 @@ data "aws_iam_policy_document" "domain" {
   }
 }
 
-resource "aws_elasticsearch_domain_policy" "domain" {
-  domain_name = aws_elasticsearch_domain.domain.domain_name
+resource "aws_elasticsearch_domain_policy" "cluster_policy" {
+  domain_name = aws_elasticsearch_domain.cluster.domain_name
 
-  access_policies = data.aws_iam_policy_document.domain.json
+  access_policies = data.aws_iam_policy_document.cluster_policy_doc.json
 }

--- a/aws/elasticsearch/terraform.tf
+++ b/aws/elasticsearch/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -22,6 +22,10 @@ variable "subnet_ids" {
   default = ""
 }
 
+variable "ingress_security_groups" {
+  default = ""
+}
+
 variable "vpc_id" {
   default = ""
 }

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -15,11 +15,12 @@ variable "es_instance_count" {
 }
 
 variable "ebs_volume_size" {
-  default = "50"
+  default = "35"
 }
 
 variable "subnet_ids" {
-  default = ""
+  type    = list
+  default = []
 }
 
 variable "ingress_security_groups" {

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -1,0 +1,32 @@
+variable "domain_name" {
+  default = "es-domain"
+}
+
+variable "es_version" {
+  default = "7.1"
+}
+
+variable "es_instance_type" {
+  default = "t2.small.elasticsearch"
+}
+
+variable "es_instance_count" {
+  default = "1"
+}
+
+variable "ebs_volume_size" {
+  default = "50"
+}
+
+variable "subnet_ids" {
+  default = ""
+}
+
+variable "vpc_id" {
+  default = ""
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
This module deploys AWS Elasticsearch clusters. 
It is very simple in it's current state, because I needed a very simple cluster. I will try to use this module for deploying more complicated clusters, thus adding more options in the future.