### PR TITLE
Creating velero-bucket module

### DIFF
--- a/aws/velero-bucket/README.md
+++ b/aws/velero-bucket/README.md
@@ -1,0 +1,28 @@
+# velero-bucket
+Creates a velero s3 bucket with a standard naming convention and tagging, also has the option of creating
+an IAM user or creating an IAM role for service accounts.
+
+Naming convention are as follows:
+
+ - bucket: `<bucket_name>-<cluster_name>-<aws account id>`
+ - IAM User: `<backup user name>-<cluster_name>`
+ - IAM Role: `<backup user name>-<cluster_name>-role`
+
+## Usage:
+```
+module "velero"  {
+  source       = "github.com/mozilla-it/terraform-modules//aws/velero-bucket?ref=master
+  cluster_name = "my-cluster"
+  create_role  = true
+}
+```
+
+Currently both `create_user` is configured to default to `false` and the preferred method of granting IAM
+access to the S3 bucket is via a role. Newer versions of EKS now has the ability to annotate a Service Account
+with an IAM role to grant the pod or deployment IAM access to the S3 bucket. However if you don't wish to do
+grant access this way you can set `create_user` to `true` and `create_role` to `false` and it will create an
+IAM access key pair for you to use for the deployment.
+
+## Other documentation
+[IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+[Velero Helm Chart](https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero)

--- a/aws/velero-bucket/README.md
+++ b/aws/velero-bucket/README.md
@@ -25,4 +25,5 @@ IAM access key pair for you to use for the deployment.
 
 ## Other documentation
 [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)
+[IRSA Blog post](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/)
 [Velero Helm Chart](https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero)

--- a/aws/velero-bucket/data.tf
+++ b/aws/velero-bucket/data.tf
@@ -1,0 +1,50 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "this" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVolumes",
+      "ec2:DescribeSnapshots",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:CreateSnapshot",
+      "ec2:DeleteSnapshot"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.this.arn
+    ]
+  }
+}
+
+data "aws_eks_cluster" "this" {
+  count = var.create_role ? 1 : 0
+  name  = var.cluster_name
+}
+

--- a/aws/velero-bucket/locals.tf
+++ b/aws/velero-bucket/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  bucket_name = "${var.bucket_name}-${var.cluster_name}-${data.aws_caller_identity.current.account_id}"
+  backup_user = "${var.backup_user}-${var.cluster_name}"
+
+  tags = merge(
+    {
+      "Region"    = var.region
+      "Service"   = "velero"
+      "Terraform" = "true"
+    },
+    var.tags
+  )
+
+}

--- a/aws/velero-bucket/main.tf
+++ b/aws/velero-bucket/main.tf
@@ -1,0 +1,64 @@
+
+#TODO: I believe this should be done together with the EKS cluster
+# creation.
+resource "aws_s3_bucket" "this" {
+  bucket = local.bucket_name
+  acl    = "private"
+
+  tags = merge({
+    "Name"    = local.backup_bucket
+    "Cluster" = var.cluster_name
+    },
+    local.tags
+  )
+
+}
+
+# TODO: Find a way to logically set create_role have
+# precedent over create_user. So if both create_role and create_user
+# are set to true we just have create_role created and create_role doesn't
+# get created
+resource "aws_iam_user" "velero_iam_user" {
+  count = var.create_user ? 1 : 0
+  name  = local.backup_user
+
+  tags = merge({
+    Name    = local.backup_user
+    Cluster = var.cluster_name
+
+    },
+    local.tags
+  )
+}
+
+resource "aws_iam_access_key" "velero_iam_access_key" {
+  count = var.create_user ? 1 : 0
+  user  = aws_iam_user.backup_user.name
+}
+
+resource "aws_iam_user_policy" "velero_iam_user_policy" {
+  count  = var.create_user ? 1 : 0
+  name   = "${local.backup_user}-policy"
+  user   = aws_iam_user.backup_user.name
+  policy = data.aws_iam_policy_document.this.json
+}
+
+# Create an IAM role for service accounts which is the recommended
+# way of doing this.
+
+module "velero_role" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "~> v2.6.0"
+  create_role                   = var.create_role
+  role_name                     = "${local.backup_user}-role"
+  provider_url                  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+  role_policy_arns              = [aws_iam_policy.this.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.velero_sa_namespace}:${var.velero_sa_name}"]
+}
+
+resource "aws_iam_policy" "velero_iam_role_policy" {
+  count       = var.create_role ? 1 : 0
+  name_prefix = "${local.backup_user}-policy"
+  description = "EKS cluster-autoscaler policy for cluster ${var.cluster_name}"
+  policy      = data.aws_iam_policy_document.this.json
+}

--- a/aws/velero-bucket/outputs.tf
+++ b/aws/velero-bucket/outputs.tf
@@ -1,0 +1,23 @@
+output "bucket_name" {
+  value = aws_s3_bucket.backup_bucket.id
+}
+
+output "velero_iam_user_name" {
+  value = aws_iam_user.velero_iam_user.name
+}
+
+output "velero_iam_user_access_key" {
+  value = aws_iam_access_key.velero_iam_access_key.id
+}
+
+output "velero_iam_user_secret_key" {
+  value = aws_iam_access_key.velero_iam_access_key.secret
+}
+
+output "velero_role_name" {
+  value = module.velero_role.this_iam_role_name
+}
+
+output "velero_role_arn" {
+  value = module.velero_role.this_iam_role_arn
+}

--- a/aws/velero-bucket/variables.tf
+++ b/aws/velero-bucket/variables.tf
@@ -1,0 +1,31 @@
+variable "region" {
+  default = "us-west-2"
+}
+
+variable "cluster_name" {}
+
+variable "bucket_name" {
+  default = "velero"
+}
+
+variable "backup_user" {
+  default = "velero"
+}
+
+variable "create_user" {
+  default = false
+}
+
+variable "create_role" {
+  default = true
+}
+
+variable "velero_sa_namespace" {
+  description = "Namespace of the velero service account"
+  default     = "velero"
+}
+
+variable "velero_sa_name" {
+  description = "Name of velero service account"
+  default     = "velero"
+}

--- a/aws/velero-bucket/versions.tf
+++ b/aws/velero-bucket/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This module will be a replacement for mozilla-it/tf-ark-backups, this
module will create an S3 bucket and an IAM role that will grant permission
to write to the bucket.

The IAM role utilizes the new IAM Role for Service Accounts feature that
was introduced last year which allows us to annotate a Service Account to
grant IAM access to the S3 bucket.

See [blog post](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) for more details