### PR TITLE
Create influx-cloudwatch module

### DIFF
--- a/aws/influx-cloudwatch/README.md
+++ b/aws/influx-cloudwatch/README.md
@@ -1,0 +1,18 @@
+# influx-cloudwatch
+
+Just a simple module to create a role that will delegate AWS access into an account to grab cloudwatch metrics. By default it allows account `177680776199` access
+
+## Usage
+
+```hcl
+module "influx_role" {
+  source = "github.com/mozilla-it/terraform-modules//aws/influx-cloudwatch?ref=master
+}
+```
+
+## Outputs
+
+| Name             | Description                |
+|------------------|----------------------------|
+| `this_role_arn`  | ARN of the role created    |
+| `this_role_name` | Name of the role           |

--- a/aws/influx-cloudwatch/main.tf
+++ b/aws/influx-cloudwatch/main.tf
@@ -1,0 +1,51 @@
+
+resource "aws_iam_role" "cloudwatch_fetch_metrics" {
+  name               = "cloudwatch_fetch_metrics"
+  path               = "/itsre/"
+  description        = "Allow a delegated account to assume role"
+  assume_role_policy = data.aws_iam_policy_document.allow_assume_role.json
+
+  tags = {
+    Name      = "cloudwatch_fetch_metrics"
+    Terraform = "true"
+  }
+}
+
+data "aws_iam_policy_document" "allow_assume_role" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.delegated_account_id}:root"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "allow_fetch_cloudwatch_metrics" {
+  name   = "allow_fetch_cloudwatch_metrics"
+  role   = aws_iam_role.cloudwatch_fetch_metrics.id
+  policy = data.aws_iam_policy_document.allow_fetch_cloudwatch_metrics.json
+}
+
+data "aws_iam_policy_document" "allow_fetch_cloudwatch_metrics" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudwatch:Describe*",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+    ]
+
+    resources = ["*"]
+  }
+}
+

--- a/aws/influx-cloudwatch/outputs.tf
+++ b/aws/influx-cloudwatch/outputs.tf
@@ -1,0 +1,8 @@
+
+output "this_role_arn" {
+  value = aws_iam_role.cloudwatch_fetch_metrics.arn
+}
+
+output "this_role_name" {
+  value = aws_iam_role.cloudwatch_fetch_metrics.name
+}

--- a/aws/influx-cloudwatch/variables.tf
+++ b/aws/influx-cloudwatch/variables.tf
@@ -1,0 +1,5 @@
+
+variable "delegated_account_id" {
+  description = "The account ID you are allowing to assume role into your account"
+  default     = "177680776199"
+}


### PR DESCRIPTION
This is a simple module to create a role for an account that is running
telegraf for influxdb to assume role into an account and grab the
cloudwatch metrics