### PR TITLE
Fixes an issue where helm CRD gets installed over and over again

### DIFF
--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -94,6 +94,14 @@ resource "helm_release" "flux_helm_operator" {
   chart      = "fluxcd/helm-operator"
   namespace  = "fluxcd"
 
+  # This option has potential to cause issues
+  # apparently helm wants you to manage CRDs outside of terraform
+  # we should investigate this more to  find out whats the downside if
+  # we leave this here.
+  # See: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+  # TODO: Figure out a way to do an out of band install of the CRD? which is ugh
+  skip_crds = true
+
   dynamic "set" {
     iterator = item
     for_each = local.flux_helm_operator_settings

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -53,8 +53,9 @@ locals {
   reloader_settings = merge(local.reloader_defaults, var.reloader_settings)
 
   flux_helm_operator_defaults = {
-    "createCRD"     = "true"
-    "helm.versions" = "v3"
+    "createCRD"          = "true"
+    "helm.versions"      = "v3"
+    "git.ssh.secretName" = "flux-git-deploy"
   }
   flux_helm_operator_settings = merge(local.flux_helm_operator_defaults, var.flux_helm_operator_settings)
 


### PR DESCRIPTION
There seems to be an issue with the flux-helm-operator chart that causes
helm to attempt to install the CRD with every run. Based on what my
understanding of the chart the `createCRD` option is meant for helm v2
but will also work with helm v3 if you give helm the `--skip-crds` flag

I made a note to figure out if this will bite us in the future and also
made a note to try to figure out a method of installing he CRD not via
helm. Also sneaked in an additional flux option to the module