### PR TITLE
 [AWS][database] Allow for choosing read replica engine version.

### DIFF
--- a/aws/database/main.tf
+++ b/aws/database/main.tf
@@ -102,7 +102,7 @@ resource "aws_db_instance" "read_replica" {
   apply_immediately    = true
   skip_final_snapshot  = "true"
   count                = var.replica_enabled == "true" ? 1 : 0
-	engine_version       = var.replica_db_version
+  engine_version       = var.replica_db_version
 
   tags = merge(
     local.tags,

--- a/aws/database/main.tf
+++ b/aws/database/main.tf
@@ -102,6 +102,7 @@ resource "aws_db_instance" "read_replica" {
   apply_immediately    = true
   skip_final_snapshot  = "true"
   count                = var.replica_enabled == "true" ? 1 : 0
+	engine_version       = var.replica_db_version
 
   tags = merge(
     local.tags,

--- a/aws/database/variables.tf
+++ b/aws/database/variables.tf
@@ -40,6 +40,10 @@ variable "db_version" {
   default = ""
 }
 
+variable "replica_db_version" {
+  default = ""
+}
+
 variable "cost_center" {
 }
 


### PR DESCRIPTION
This is needed for upgrading a DB with a read replica. First the replica needs to be updated and later the master

