### PR TITLE
Split out flux helm installation to its own module

### DIFF
--- a/helm/flux/README.md
+++ b/helm/flux/README.md
@@ -1,0 +1,92 @@
+# flux
+Installs fluxcd and flux helm operator using terraform,  to make this module work you will need to include a couple of providers
+in order for this to work
+
+## Usage
+In order to get helm chart installed on your charts installed you need to use the helm provider and here is an example on
+how to set this up for AWS and GCP
+
+Example setup for AWS
+```hcl
+data "aws_eks_cluster" "cluster" {
+  name = "your-cluster-name"
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = "your-cluster-name"
+}
+
+provider "helm" {
+  version = "~> 1"
+
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    load_config_file       = false
+  }
+}
+
+module "flux" {
+  source = "github.com/mozilla-it/terraform-modules//helm/flux?ref=master
+  flux_settings = {
+    "git.url"  = "git@github.com:username/repo"
+    "git.path" = "folder"
+  }
+}
+```
+
+Example setup for GCP
+```hcl
+data "google_container_cluster" "cluster" {
+  name  = "my-cluster-name"
+}
+
+data "google_client_config" "current" {
+}
+
+provider "helm" {
+  version = "~> 1"
+
+  kubernetes {
+    host                   = data.google_container_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
+    client_key             = base64decode(data.google_container_cluster.cluster.master_auth.0.client_key)
+    client_certificate     = base64decode(data.google_container_cluster.cluster.master_auth.0.client_certificate)
+    token                  = data.google_client_config.current.access_token
+    load_config_file       = false
+  }
+}
+
+module "flux" {
+  source = "github.com/mozilla-it/terraform-modules//helm/flux?ref=master
+  flux_settings = {
+    "git.url"  = "git@github.com:username/repo"
+    "git.path" = "folder"
+  }
+}
+ ```
+
+## Inputs
+Default values of each input can be found in the [locals.tf](https://github.com/mozilla-it/terraform-modules/blob/master/helm/flux/locals.tf) file and if you want to override
+the default settings all you have to create a map of the value you to override as an example
+
+Example of overriding namespace:
+```hcl
+locals {
+  flux_settings = {
+    "namespace" = "kube-system"
+    "git.url"   = "git@github.com:username/repo"
+    "git.path"  = "folder"
+  }
+}
+
+module "flux" {
+  source        = "github.com/mozilla-it/terraform-modules//helm/flux?ref=master
+  flux_settings = local.flux_settings
+}
+```
+
+## Other links
+* [Flux helm operator chart configuration values](https://github.com/fluxcd/helm-operator/tree/master/chart/helm-operator#configuration)
+* [Flux chart configuration values](https://github.com/fluxcd/flux/tree/master/chart/flux#configuration)

--- a/helm/flux/data.tf
+++ b/helm/flux/data.tf
@@ -1,0 +1,11 @@
+data "helm_repository" "fluxcd" {
+  count = var.enable_flux ? 1 : 0
+  name  = "fluxcd"
+  url   = "https://charts.fluxcd.io"
+}
+
+data "helm_repository" "stable" {
+  count = var.enable_flux && var.enable_flux_helm_operator ? 1 : 0
+  name  = "stable"
+  url   = "https://kubernetes-charts.storage.googleapis.com"
+}

--- a/helm/flux/locals.tf
+++ b/helm/flux/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  flux_helm_operator_defaults = {
+    "createCRD"          = "true"
+    "helm.versions"      = "v3"
+    "git.ssh.secretName" = "flux-git-deploy"
+    "namespace"          = "fluxcd"
+  }
+  flux_helm_operator_settings = merge(local.flux_helm_operator_defaults, var.flux_helm_operator_settings)
+
+  flux_defaults = {
+    "git.ciSkip" = "true"
+    "namespace"  = "fluxcd"
+  }
+  flux_settings = merge(local.flux_defaults, var.flux_settings)
+
+}

--- a/helm/flux/main.tf
+++ b/helm/flux/main.tf
@@ -1,0 +1,41 @@
+
+# Logic here is we can enable flux on its own and it can just run flux without operator
+# but there is not really a point in running the helm operator without flux
+
+resource "helm_release" "flux_helm_operator" {
+  count      = var.enable_flux && var.enable_flux_helm_operator ? 1 : 0
+  name       = "helm-operator"
+  repository = data.helm_repository.fluxcd[0].metadata.0.name
+  chart      = "fluxcd/helm-operator"
+  namespace  = local.flux_helm_operator_settings["namespace"]
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.flux_helm_operator_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+
+  skip_crds = true
+}
+
+resource "helm_release" "fluxcd" {
+  count      = var.enable_flux ? 1 : 0
+  name       = "flux"
+  repository = data.helm_repository.fluxcd[0].metadata.0.name
+  chart      = "fluxcd/flux"
+  namespace  = local.flux_settings["namespace"]
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.flux_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+}

--- a/helm/flux/variables.tf
+++ b/helm/flux/variables.tf
@@ -1,0 +1,17 @@
+variable "flux_helm_operator_settings" {
+  type    = any
+  default = {}
+}
+
+variable "flux_settings" {
+  type    = any
+  default = {}
+}
+
+variable "enable_flux" {
+  default = true
+}
+
+variable "enable_flux_helm_operator" {
+  default = true
+}


### PR DESCRIPTION
To help facilitate support for both AWS and GCP the installation of flux
and flux helm operator has been moved to its own folder as a module so
that its possible for anyone with a kubernetes cluster who wants to use
this can use it by including the module.

README has steps on how to set this up.