### PR TITLE
Yet another refactor

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -6,6 +6,8 @@ by default, packages installed listed below:
  - `metrics-server` - metrics server we all know and love
  - `cluster-autoscaler` - Cluster autoscaler
  - `reloader` - Reloads a deployment when you update a configmap or secret
+ - `sealed-secrets` - A controller that enables you check in secrets in git and the controller decrypts secrets
+ - `flux` - This is an optional package and installs the flux package
  - `helm-operator` - This is an optional package and installs the flux helm operator
 
 ## Usage
@@ -82,7 +84,6 @@ module "eks" {
   cluster_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
   node_groups     = local.node_groups
 }
-
 ```
 
 ## Inputs

--- a/aws/eks/flux.tf
+++ b/aws/eks/flux.tf
@@ -1,7 +1,14 @@
 
 resource "kubernetes_namespace" "flux" {
-  count = var.enable_flux ? 1 : 0
+  count = local.cluster_features["flux"] ? 1 : 0
   metadata {
     name = "fluxcd"
   }
+}
+
+module "flux" {
+  source                    = "github.com/mozilla-it/terraform-modules//helm/flux?ref=master"
+  enable_flux               = local.cluster_features["flux"]
+  enable_flux_helm_operator = local.cluster_features["flux_helm_operator"]
+  flux_settings             = var.flux_settings
 }

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -8,6 +8,17 @@ locals {
     var.tags,
   )
 
+  cluster_features_defaults = {
+    "cluster_autoscaler" = true
+    "metrics_server"     = true
+    "reloader"           = true
+    "velero"             = true
+    "sealed_secrets"     = true
+    "flux"               = false
+    "flux_helm_operator" = false
+  }
+  cluster_features = merge(local.cluster_features_defaults, var.cluster_features)
+
   cluster_log_type = var.enable_logging ? ["api", "audit", "authenticator", "controllerManager", "scheduler"] : []
 
   cluster_autoscaler_name_prefix               = "${module.eks.cluster_id}-cluster-autoscaler"
@@ -27,14 +38,6 @@ locals {
     "1.17" = "v1.17.1"
   }
 
-  kube_state_metrics_versions = {
-    "1.13" = "v1.6.0"
-    "1.14" = "v1.7.2"
-    "1.15" = "v1.8.0"
-    "1.16" = "v1.9.5"
-    "1.17" = "master"
-  }
-
   cluster_autoscaler_defaults = {
     "awsRegion"                                                     = var.region
     "image.tag"                                                     = lookup(local.cluster_autoscaler_versions, var.cluster_version)
@@ -52,18 +55,6 @@ locals {
   }
   reloader_settings = merge(local.reloader_defaults, var.reloader_settings)
 
-  flux_helm_operator_defaults = {
-    "createCRD"          = "true"
-    "helm.versions"      = "v3"
-    "git.ssh.secretName" = "flux-git-deploy"
-  }
-  flux_helm_operator_settings = merge(local.flux_helm_operator_defaults, var.flux_helm_operator_settings)
-
-  flux_defaults = {
-    "git.ciSkip" = "true"
-  }
-  flux_settings = merge(local.flux_defaults, var.flux_settings)
-
   # Settings taken from
   # https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero
   velero_defaults = {
@@ -71,8 +62,6 @@ locals {
     "configuration.backupStorageLocation.name"                         = "aws"
     "configuration.backupStorageLocation.bucket"                       = module.velero.bucket_name
     "configuration.backupStorageLocation.config.region"                = var.region
-    "configuration.volumeSnapshotLocation.name"                        = "aws"
-    "configuration.volumeSnapshotLocation.config.region"               = var.region
     "configuration.volumeSnapshotLocation.name"                        = "aws"
     "configuration.volumeSnapshotLocation.config.region"               = var.region
     "serviceAccount.server.name"                                       = "velero"

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -7,6 +7,17 @@ provider "kubernetes" {
   version                = "~> 1"
 }
 
+provider "helm" {
+  version = "~> 1"
+
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+    load_config_file       = false
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "ssm" {
   role       = module.eks.worker_iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -45,10 +45,6 @@ variable "worker_groups" {
   default     = []
 }
 
-variable "enable_flux" {
-  default = false
-}
-
 variable "enable_logging" {
   default = false
 }
@@ -57,12 +53,10 @@ variable "log_retention" {
   default = "30"
 }
 
-variable "enable_velero" {
-  default = true
-}
-
-variable "enable_sealed_secrets" {
-  default = true
+variable "cluster_features" {
+  description = "Map of features to enable on cluster, see local.tf for all feature flags"
+  type        = map(string)
+  default     = {}
 }
 
 variable "cluster_autoscaler_settings" {

--- a/aws/eks/velero.tf
+++ b/aws/eks/velero.tf
@@ -1,16 +1,18 @@
 
 resource "kubernetes_namespace" "velero" {
-  count = var.enable_velero ? 1 : 0
+  count = local.cluster_features["velero"] ? 1 : 0
 
   metadata {
     name = "velero"
   }
+
+  depends_on = [module.eks]
 }
 
 module "velero" {
   source              = "github.com/mozilla-it/terraform-modules//aws/velero-bucket?ref=master"
   cluster_name        = module.eks.cluster_id
-  create_bucket       = var.enable_velero
+  create_bucket       = local.cluster_features["velero"]
   velero_sa_namespace = "velero"
   velero_sa_name      = "velero"
 }


### PR DESCRIPTION
This is yet another refactor, since we've moved flux into its own module in PR #40 I'm going to refactor this module a little bit:

Summary of changes:

- Remove helm_release installation in the eks module and replaced it the independent module
- Remove the `enable_*` flags and moved all of that into the `cluster_features` map
- Cleanup variables that is no longer needed

Note: Velero had to be pinned to version 2.9.8 because of vmware-tanzu/helm-charts#93 and until that is fixed we will stay at that version.