### PR TITLE
Add KMS key id for velero helm chart

### DIFF
--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -63,6 +63,7 @@ locals {
     "configuration.backupStorageLocation.name"                         = "aws"
     "configuration.backupStorageLocation.bucket"                       = module.velero.bucket_name
     "configuration.backupStorageLocation.config.region"                = var.region
+    "configuration.backupStorageLocation.config.kmsKeyId"              = module.velero.velero_kms_key_id
     "configuration.volumeSnapshotLocation.name"                        = "aws"
     "configuration.volumeSnapshotLocation.config.region"               = var.region
     "serviceAccount.server.name"                                       = "velero"


### PR DESCRIPTION
Adding a KMS key id to the velero chart, the s3 bucket now has Server side encryption which means we can do encryption at rest during cluster backups now.