### PR TITLE
Enable garbage collection and pod security policy for flux

### DIFF
--- a/helm/flux/locals.tf
+++ b/helm/flux/locals.tf
@@ -8,8 +8,10 @@ locals {
   flux_helm_operator_settings = merge(local.flux_helm_operator_defaults, var.flux_helm_operator_settings)
 
   flux_defaults = {
-    "git.ciSkip" = "true"
-    "namespace"  = "fluxcd"
+    "git.ciSkip"                    = true
+    "rbac.pspEnabled"               = true
+    "syncGarbageCollection.enabled" = true
+    "namespace"                     = "fluxcd"
   }
   flux_settings = merge(local.flux_defaults, var.flux_settings)
 


### PR DESCRIPTION
- Enables garbage collection for helm to remove any items that has been removed from git. See https://github.com/fluxcd/flux/blob/master/docs/references/garbagecollection.md for details
- Enable pod security policy for flux pod