### PR TITLE
[aws][database] better defaults

### DIFF
--- a/aws/database/main.tf
+++ b/aws/database/main.tf
@@ -85,7 +85,7 @@ resource "aws_db_instance" "default" {
   parameter_group_name                  = var.parameter_group_name != "" ? var.parameter_group_name : "default.${var.type}${local.ver}"
   backup_retention_period               = var.backup_retention_period
   performance_insights_enabled          = var.performance_insights_enabled
-  performance_insights_retention_period = var.performance_insights_retention
+  performance_insights_retention_period = var.performance_insights_enabled == "false" ? 0 : var.performance_insights_retention
   snapshot_identifier                   = var.snapshot_identifier
   allow_major_version_upgrade           = var.allow_major_version_upgrade
 


### PR DESCRIPTION
This change adds compatibility with old databases created using this module.
Before this, a terraform plan will show this change: `performance_insights_retention_period = 0 -> 7` even if keeping `performance_insights = false`.
With this change terraform plan runs smooth