### PR TITLE
Add region to role name to namespace it

### DIFF
--- a/aws/eks/autoscaler.tf
+++ b/aws/eks/autoscaler.tf
@@ -7,6 +7,7 @@ module "cluster_autoscaler_role" {
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${local.cluster_autoscaler_service_account_namespace}:${local.cluster_autoscaler_service_account_name}"]
+  tags                          = merge({ "Name" = local.cluster_autoscaler_name_prefix }, local.tags)
 }
 
 resource "aws_iam_policy" "cluster_autoscaler" {

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -22,7 +22,7 @@ locals {
 
   cluster_log_type = var.enable_logging ? ["api", "audit", "authenticator", "controllerManager", "scheduler"] : []
 
-  cluster_autoscaler_name_prefix               = "${module.eks.cluster_id}-cluster-autoscaler"
+  cluster_autoscaler_name_prefix               = "${module.eks.cluster_id}-cluster-autoscaler-${var.region}"
   cluster_autoscaler_service_account_namespace = "kube-system"
   cluster_autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler"
 


### PR DESCRIPTION
Attempt to namespace the role name for cluster-autoscaler, this is to get around issues when you create multiple clusters in multiple regions