### PR TITLE
Fix velero role creation error 

### DIFF
--- a/aws/eks/velero.tf
+++ b/aws/eks/velero.tf
@@ -14,6 +14,7 @@ module "velero" {
   region              = var.region
   cluster_name        = module.eks.cluster_id
   create_bucket       = var.create_eks && local.cluster_features["velero"]
+  create_role         = var.create_eks && local.cluster_features["velero"]
   bucket_name         = var.velero_bucket_name
   velero_sa_namespace = "velero"
   velero_sa_name      = "velero"

--- a/aws/velero-bucket/main.tf
+++ b/aws/velero-bucket/main.tf
@@ -60,8 +60,8 @@ module "velero_role" {
   version                       = "~> v2.10.0"
   create_role                   = var.create_role
   role_name                     = "${local.backup_user}-role"
-  provider_url                  = replace(data.aws_eks_cluster.this[0].identity.0.oidc.0.issuer, "https://", "")
-  role_policy_arns              = [aws_iam_policy.velero_iam_role_policy[0].arn]
+  provider_url                  = var.create_role ? replace(data.aws_eks_cluster.this[0].identity.0.oidc.0.issuer, "https://", "") : ""
+  role_policy_arns              = var.create_role ? [aws_iam_policy.velero_iam_role_policy[0].arn] : []
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.velero_sa_namespace}:${var.velero_sa_name}"]
 }
 


### PR DESCRIPTION
When velero is set to `false` in `cluster_features` map the role creation actually throws an error. Fix this by setting an input ternary to pass empty values  if values its set to `false`