### PR TITLE
adding custom version support to gke and setting default version to 1.16

### DIFF
--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -1,14 +1,25 @@
 
+data "google_container_engine_versions" "gkeversions" {
+  provider       = google-beta
+  location       = var.region
+  version_prefix = "${var.min_master_version}."
+}
+
 resource "google_container_cluster" "primary" {
-  name     = var.name
-  location = var.region
-  provider = google-beta
+  name               = var.name
+  location           = var.region
+  provider           = google-beta
+  min_master_version = data.google_container_engine_versions.gkeversions.latest_node_version
 
   remove_default_node_pool = true
   initial_node_count       = 1
 
   workload_identity_config {
     identity_namespace = "${var.project_id}.svc.id.goog"
+  }
+
+  release_channel {
+    channel = var.release_channel
   }
 
   addons_config {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -15,3 +15,7 @@ variable "istio_disabled" { default = true }
 variable "min_nodes_per_zone" { default = 1 }
 
 variable "max_nodes_per_zone" { default = 5 }
+
+variable "release_channel" { default = "REGULAR" }
+
+variable "min_master_version" { default = "1.16" }


### PR DESCRIPTION
It should be noted that setting versions and changing release channels in gke are a little weird, and you have to be a little cautious, but if you do it wrong the error messages are pretty verbose. 

You can't upgrade more than one major version at a time, so you have to keep that in mind when changing release channels or min version. And be careful that you pick a version that's in the specified release channel.

I've tested this with a new cluster, and overrode the defaults to create a 1.17 cluster from the rapid channel.

https://jira.mozilla.com/browse/SE-1174