### PR TITLE
Remove cluster naming detection logic

### DIFF
--- a/gcp/gke/locals.tf
+++ b/gcp/gke/locals.tf
@@ -1,6 +1,5 @@
 
 locals {
-  name = var.environment == "" ? var.name : "${var.name}-${var.environment}"
 
   cluster_addons_defaults = {
     horizontal_pod_autoscaling = true

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -10,7 +10,7 @@ module "gke" {
   kubernetes_version              = var.kubernetes_version
   release_channel                 = var.release_channel
   project_id                      = var.project_id
-  name                            = local.name
+  name                            = var.name
   region                          = var.region
   regional                        = var.regional
   zones                           = random_shuffle.zones.result
@@ -31,7 +31,7 @@ module "gke" {
   node_pools    = var.node_pools
   node_pools_labels = {
     all = {
-      "cluster"     = local.name
+      "cluster"     = var.name
       "environment" = var.environment
       "node"        = "managed"
       "costcenter"  = var.costcenter
@@ -41,7 +41,7 @@ module "gke" {
 
   node_pools_tags = {
     all = [
-      var.project_id, local.name, var.region
+      var.project_id, var.name, var.region
     ]
   }
 

--- a/gcp/gke/velero.tf
+++ b/gcp/gke/velero.tf
@@ -37,14 +37,14 @@ resource "google_service_account" "velero" {
   project      = var.project_id
   account_id   = local.sa_name
   display_name = local.sa_name
-  description  = "Service account for velero on cluster ${local.name}"
+  description  = "Service account for velero on cluster ${var.name}"
 }
 
 resource "google_project_iam_custom_role" "velero" {
   count       = local.cluster_features["velero"] ? 1 : 0
-  role_id     = "velero.server.${replace(local.name, "-", "_")}"
-  title       = "Velero Server ${local.name}"
-  description = "Custom role for velero on cluster ${local.name}"
+  role_id     = "velero.server.${replace(var.name, "-", "_")}"
+  title       = "Velero Server ${var.name}"
+  description = "Custom role for velero on cluster ${var.name}"
 
   permissions = [
     "compute.disks.get",


### PR DESCRIPTION
This PR removes the ability for cluster names to be named a certain way if `var.environment` is provided, instead we leave the naming of clusters to be independent and `var.environment` is there to add as a label to node groups and tags to node groups as well