### PR TITLE
[aws] Bump terraform modules

### DIFF
--- a/aws/eks/alb.tf
+++ b/aws/eks/alb.tf
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "alb" {
 
 module "alb_ingress_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.10.0"
+  version                       = "~> v2.12.0"
   create_role                   = var.create_eks && local.cluster_features["alb_ingress"]
   role_name                     = local.alb_ingress_name_prefix
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/aws/eks/autoscaler.tf
+++ b/aws/eks/autoscaler.tf
@@ -1,7 +1,7 @@
 
 module "cluster_autoscaler_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.10.0"
+  version                       = "~> v2.12.0"
   create_role                   = true
   role_name                     = local.cluster_autoscaler_name_prefix
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/aws/eks/external_secrets.tf
+++ b/aws/eks/external_secrets.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "external_secrets" {
 
 module "external_secrets" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.10.0"
+  version                       = "~> v2.12.0"
   create_role                   = var.create_eks && local.cluster_features["external_secrets"]
   role_name                     = local.external_secrets_role_name
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -26,7 +26,7 @@ resource "aws_iam_role_policy_attachment" "ssm" {
 module "eks" {
   source                        = "terraform-aws-modules/eks/aws"
   create_eks                    = var.create_eks
-  version                       = "~> 11"
+  version                       = "~> 12"
   cluster_name                  = var.cluster_name
   cluster_version               = var.cluster_version
   cluster_enabled_log_types     = local.cluster_log_type

--- a/aws/velero-bucket/main.tf
+++ b/aws/velero-bucket/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_user_policy" "velero_iam_user_policy" {
 
 module "velero_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.10.0"
+  version                       = "~> v2.12.0"
   create_role                   = var.create_role
   role_name                     = "${local.backup_user}-role"
   provider_url                  = var.create_role ? replace(data.aws_eks_cluster.this[0].identity.0.oidc.0.issuer, "https://", "") : ""

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -1,5 +1,5 @@
 ## VPC module
-This is a module that calls the [terraform registry vpc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/1.72.0) module.
+This is a module that calls the [terraform registry vpc](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/2.44.0) module.
 That being said it simplifies the calling of the registry module by doing the subnet cidr calculations for you. This module does assume that you
 will only have a `private` and `public` subnet only
 

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -29,7 +29,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.24.0"
+  version = "2.44.0"
 
   create_vpc             = var.enable_vpc
   name                   = var.name


### PR DESCRIPTION
Bump upstream vpc, eks and IAM module versions, they're all minor changes and don't really affect a lot of things based on my  tests

Should not have breaking changes