### PR TITLE
[aws][eks] Abstract aws_auth CM for admin users

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -114,6 +114,7 @@ module "eks" {
 | `flux_settings`                | Map to customize or override default helm chart values for flux                                      | `{}          |
 | `log_retention`                | Number of days to retain log events                                                                  | `30`         |
 | `tags`                         | A map of tags to add to all resources.                                                               | `{}`         |
+| `admin_users_arn`              | A list of ARNs to be mapped as global cluster admins.                                                | `[]`         |
 
 ## Other documentation
 

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -118,4 +118,15 @@ locals {
   }
 
   node_groups = length(var.node_groups) > 0 ? var.node_groups : local.default_node_groups
+
+  admin_users = [for role in var.admin_users_arn :
+    {
+      username = "cluster-admin",
+      rolearn  = role,
+      groups   = ["system:masters"]
+    }
+  ]
+
+  roles_expanded = length(local.admin_users) > 0 ? concat(local.admin_users, var.map_roles) : var.map_roles
+
 }

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -38,7 +38,7 @@ module "eks" {
   node_groups          = local.node_groups
   node_groups_defaults = local.node_groups_defaults
 
-  map_roles    = var.map_roles
+  map_roles    = local.roles_expanded
   map_users    = var.map_users
   map_accounts = var.map_accounts
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -134,3 +134,8 @@ variable "external_secrets_secret_paths" {
   default     = ["*"]
 }
 
+variable "admin_users_arn" {
+  description = "List of ARNs to be mapped as a cluster global admins"
+  type        = list
+  default     = []
+}


### PR DESCRIPTION
Because every cluster needs a list of Admins, it makes sense abstracting
theis creation based on a list of arns. It reduces the amount of lines
needed to create a cluster.