### PR TITLE
[gcp][gke] Update identity module to have KSA creation be an option

### DIFF
--- a/gcp/identity/README.md
+++ b/gcp/identity/README.md
@@ -1,0 +1,46 @@
+# Identity module
+Connects Kubernetes Service Accounts (KSA) with GCP Service Accounts (GSA) to enable the use of `Workload Identity` for kubernetes to access GCP resources
+
+This module creates:
+
+ * GCP Service Account
+ * IAM Service Account binding to `roles/iam.workloadIdentityUser`
+ * A Kubernetes service account which can be optionally be disabled
+ * Attaches `roles/secretmanager.secretAccessor` and `roles/logging.logWriter` role
+
+## Usage:
+
+Basic usage that creates kubernetes service account as well as annotating the service account
+
+```hcl
+module "sample-workload-identity" {
+  source      = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master
+  name        = "my-service-account"
+  namespace   = "my-service-account-namespace"
+  gke_cluster = "my-gke-cluster"
+  project_id  = "my-project-id"
+}
+```
+
+Using module if there you have an existing kubernetes service account
+
+```hcl
+resource "kubernetes_service_account" "preexisting" {
+  metadata {
+    name = "my-service-account"
+    namespace = "my-service-account-namespace"
+    annotations = {
+      "iam.gke.io/gcp-service-account" = "my-service-account@${var.project_id}.iam.gserviceaccount.com"
+    }
+  }
+}
+
+module "sample-workload-identity" {
+  source      = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master
+  create_ksa  = false
+  name        = "my-service-account"
+  namespace   = "my-service-account-namespace"
+  gke_cluster = "my-gke-cluster"
+  project_id  = "my-project-id"
+}
+```

--- a/gcp/identity/main.tf
+++ b/gcp/identity/main.tf
@@ -1,29 +1,55 @@
+locals {
+
+  # Shamelessly stolen from https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/7.1.0/submodules/workload-identity
+  k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.name}]"
+  gsa_email               = var.enabled ? google_service_account.gsa[0].email : ""
+  gsa_fqdn                = var.enabled ? "serviceAccount:${google_service_account.gsa[0].email}" : null
+
+  # This will cause terraform to block returning outputs until the service account is created
+  output_k8s_name      = var.create_ksa ? kubernetes_service_account.ksa[0].metadata[0].name : var.name
+  output_k8s_namespace = var.create_ksa ? kubernetes_service_account.ksa[0].metadata[0].namespace : var.namespace
+}
 
 resource "google_service_account" "gsa" {
+  count      = var.enabled ? 1 : 0
   account_id = var.name
   project    = var.project_id
   provider   = google-beta
 }
 
+# NOTE: Consider moving this outside of this module?
+#       This allows accessing of secrets versions and viewing of secrets
+#       should really figure out how to scope this as well
 resource "google_project_iam_member" "iam" {
+  count    = var.enabled && var.additional_permissions ? 1 : 0
   project  = var.project_id
-  role     = "roles/secretmanager.admin"
-  member   = "serviceAccount:${google_service_account.gsa.email}"
+  role     = "roles/secretmanager.secretAccessor"
+  member   = local.gsa_fqdn
+  provider = google-beta
+}
+
+resource "google_project_iam_member" "iam-secret-viewing" {
+  count    = var.enabled && var.additional_permissions ? 1 : 0
+  project  = var.project_id
+  role     = "roles/secretmanager.viewer"
+  member   = local.gsa_fqdn
   provider = google-beta
 }
 
 resource "google_project_iam_member" "iam-logging" {
+  count   = var.enabled && var.additional_permissions ? 1 : 0
   project = var.project_id
   role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.gsa.email}"
+  member  = local.gsa_fqdn
 }
 
 resource "kubernetes_service_account" "ksa" {
+  count = var.enabled && var.create_ksa ? 1 : 0
   metadata {
     namespace = var.namespace
     name      = var.name
     annotations = {
-      "iam.gke.io/gcp-service-account" = google_service_account.gsa.email
+      "iam.gke.io/gcp-service-account" = local.gsa_email
     }
   }
   automount_service_account_token = true
@@ -33,17 +59,12 @@ resource "kubernetes_service_account" "ksa" {
 }
 
 resource "google_service_account_iam_binding" "ksa-gsa-binding" {
+  count              = var.enabled ? 1 : 0
   provider           = google-beta
-  service_account_id = google_service_account.gsa.name
+  service_account_id = google_service_account.gsa[0].name
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    "serviceAccount:${var.project_id}.svc.id.goog[${kubernetes_service_account.ksa.metadata.0.namespace}/${kubernetes_service_account.ksa.metadata.0.name}]",
+    local.k8s_sa_gcp_derived_name
   ]
-
-  depends_on = [
-    kubernetes_service_account.ksa,
-  ]
-
 }
-

--- a/gcp/identity/outputs.tf
+++ b/gcp/identity/outputs.tf
@@ -1,0 +1,20 @@
+
+output "k8s_service_account_name" {
+  description = "Name of k8s service account."
+  value       = local.output_k8s_name
+}
+
+output "k8s_service_account_namespace" {
+  description = "Namespace of k8s service account."
+  value       = local.output_k8s_namespace
+}
+
+output "gcp_service_account_email" {
+  description = "Email address of GCP service account."
+  value       = local.gsa_email
+}
+
+output "gcp_service_account_fqn" {
+  description = "FQN of GCP service account."
+  value       = local.gsa_fqdn
+}

--- a/gcp/identity/variables.tf
+++ b/gcp/identity/variables.tf
@@ -4,4 +4,24 @@ variable "name" {}
 
 variable "gke_cluster" {}
 
-variable "namespace" { default = "default" }
+variable "namespace" {
+  description = "Namespace SA will be created in"
+  default     = "default"
+}
+
+variable "enabled" {
+  default = true
+  type    = bool
+}
+
+variable "create_ksa" {
+  description = "Create kubernetes service account instead of using existing one, KSA will be named using `var.name`"
+  type        = bool
+  default     = true
+}
+
+variable "additional_permissions" {
+  description = "Option to add additonal `secretmanager.secretAccessor` and `logging.logWriter` permission to SA"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Refactor `identity` module to be able to optionally not create the kubernetes service account as well as a flag to enable or disable this module

Added a readme on how to use this module.