### PR TITLE
[gcp][gke] Add external secrets helm chart

### DIFF
--- a/gcp/gke/external_secrets.tf
+++ b/gcp/gke/external_secrets.tf
@@ -1,5 +1,4 @@
 
-# Less than ideal situation because we can't feature flag it
 module "external-secrets-workload-identity" {
   source      = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master"
   enabled     = local.cluster_features["external_secrets"]

--- a/gcp/gke/external_secrets.tf
+++ b/gcp/gke/external_secrets.tf
@@ -1,0 +1,11 @@
+
+# Less than ideal situation because we can't feature flag it
+module "external-secrets-workload-identity" {
+  source      = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master"
+  enabled     = local.cluster_features["external_secrets"]
+  create_ksa  = false # Allow chart to create
+  name        = "kubernetes-external-secrets"
+  namespace   = "kube-system"
+  gke_cluster = module.gke.name
+  project_id  = var.project_id
+}

--- a/gcp/gke/helm.tf
+++ b/gcp/gke/helm.tf
@@ -1,7 +1,8 @@
 locals {
-  helm_stable_repository       = "https://kubernetes-charts.storage.googleapis.com"
-  helm_incubator_repository    = "http://storage.googleapis.com/kubernetes-charts-incubator"
-  helm_vmware_tanzu_repository = "https://vmware-tanzu.github.io/helm-charts"
+  helm_stable_repository           = "https://kubernetes-charts.storage.googleapis.com"
+  helm_incubator_repository        = "http://storage.googleapis.com/kubernetes-charts-incubator"
+  helm_vmware_tanzu_repository     = "https://vmware-tanzu.github.io/helm-charts"
+  helm_external_secrets_repository = "https://godaddy.github.io/kubernetes-external-secrets"
 }
 
 resource "helm_release" "velero" {
@@ -22,4 +23,23 @@ resource "helm_release" "velero" {
   }
 
   depends_on = [module.gke]
+}
+
+resource "helm_release" "external_secrets" {
+  count      = local.cluster_features["external_secrets"] ? 1 : 0
+  name       = "kubernetes-external-secrets"
+  repository = local.helm_external_secrets_repository
+  chart      = "kubernetes-external-secrets"
+  namespace  = "kube-system"
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.external_secrets_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+
 }

--- a/gcp/gke/locals.tf
+++ b/gcp/gke/locals.tf
@@ -23,6 +23,7 @@ locals {
   cluster_features_defaults = {
     "velero"             = false
     "prometheus"         = false
+    "external_secrets"   = false
     "flux"               = false
     "flux_helm_operator" = false
   }
@@ -50,5 +51,14 @@ locals {
     "alertmanager.persistentVolume.size"         = "25Gi"
   }
   prometheus_settings = merge(local.prometheus_defaults, var.prometheus_settings)
+
+  external_secrets_defaults = {
+    "securityContext.fsGroup"                                       = "65534"
+    "env.POLLER_INTERVAL_MILLISECONDS"                              = "300000"
+    "serviceAccount.name"                                           = "kubernetes-external-secrets"
+    "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account" = "kubernetes-external-secrets@${var.project_id}.iam.gserviceaccount.com"
+
+  }
+  external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)
 
 }

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -93,3 +93,9 @@ variable "prometheus_settings" {
   type        = map(string)
   default     = {}
 }
+
+variable "external_secrets_settings" {
+  description = "Settings for external secrets helm chart"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Add godaddy's external-secrets helm chart as an option to install on the GKE cluster