### PR TITLE
Create prometheus helm module that is usable by both aws and gcp

### DIFF
--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -14,6 +14,7 @@ locals {
     "metrics_server"     = true
     "reloader"           = true
     "velero"             = true
+    "prometheus"         = false
     "sealed_secrets"     = false
     "aws_calico"         = false
     "alb_ingress"        = false

--- a/aws/eks/monitoring.tf
+++ b/aws/eks/monitoring.tf
@@ -1,6 +1,7 @@
+
 module "prometheus" {
   source                   = "github.com/mozilla-it/terraform-modules//helm/prometheus?ref=master"
   enabled                  = local.cluster_features["prometheus"]
-  cloud_provider           = "gcp"
+  cloud_provider           = "aws"
   prometheus_helm_settings = var.prometheus_settings
 }

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -122,6 +122,12 @@ variable "alb_ingress_settings" {
   default     = {}
 }
 
+variable "prometheus_settings" {
+  description = "Customized or override prometheus helm chart values"
+  type        = map(string)
+  default     = {}
+}
+
 variable "external_secrets_settings" {
   description = "Customize or override kubernetes_external_secrets helm chart values"
   type        = map(string)

--- a/gcp/gke/locals.tf
+++ b/gcp/gke/locals.tf
@@ -43,15 +43,6 @@ locals {
   }
   velero_settings = merge(local.velero_defaults, var.velero_settings)
 
-  #NOTE: Consider setting up pd-ssd storage class
-  prometheus_defaults = {
-    "server.persistentVolume.storageClass"       = "standard" # Up for discussion
-    "server.persistentVolume.size"               = "50Gi"     # Without any idea of what normal is I'm just setting this as a random value
-    "alertmanager.persistentVolume.storageClass" = "standard"
-    "alertmanager.persistentVolume.size"         = "25Gi"
-  }
-  prometheus_settings = merge(local.prometheus_defaults, var.prometheus_settings)
-
   external_secrets_defaults = {
     "securityContext.fsGroup"                                       = "65534"
     "env.POLLER_INTERVAL_MILLISECONDS"                              = "300000"

--- a/gcp/gke/monitoring.tf
+++ b/gcp/gke/monitoring.tf
@@ -2,5 +2,6 @@ module "prometheus" {
   source                   = "github.com/mozilla-it/terraform-modules//helm/prometheus?ref=master"
   enabled                  = local.cluster_features["prometheus"]
   cloud_provider           = "gcp"
+  storage_class            = { "gcp" = "faster" }
   prometheus_helm_settings = var.prometheus_settings
 }

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -14,7 +14,7 @@ variable "kubernetes_version" {
 variable "release_channel" {
   type        = string
   description = "(Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`."
-  default     = null
+  default     = "REGULAR"
 }
 
 variable "costcenter" {}

--- a/helm/prometheus/README.md
+++ b/helm/prometheus/README.md
@@ -1,0 +1,13 @@
+# Prometheus module
+Installs prometheus via a helm chart, this supports both gcp and aws
+
+## Usage
+
+```hcl
+module "prometheus" {
+  source         = "github.com/mozilla-it/terraform-modules//helm/prometheus?ref=master
+  enabled        = true
+  cloud_provider = "aws"
+}
+```
+

--- a/helm/prometheus/locals.tf
+++ b/helm/prometheus/locals.tf
@@ -9,10 +9,10 @@ locals {
 
   prometheus_helm_defaults = {
     "server.persistentVolume.storageClass"       = lookup(local.storage_class, var.cloud_provider, "gp2")
-    "server.persistentVolume.size"               = "500Gi"
+    "server.persistentVolume.size"               = "20Gi"
     "server.retention"                           = "7d"
     "alertmanager.persistentVolume.storageClass" = lookup(local.storage_class, var.cloud_provider, "gp2")
-    "alertmanager.persistentVolume.size"         = "100Gi"
+    "alertmanager.persistentVolume.size"         = "5Gi"
   }
   prometheus_helm_settings = merge(local.prometheus_helm_defaults, var.prometheus_helm_settings)
 

--- a/helm/prometheus/locals.tf
+++ b/helm/prometheus/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  helm_stable_repository = "https://kubernetes-charts.storage.googleapis.com"
+
+  storage_class_defaults = {
+    "aws" = "gp2"
+    "gcp" = "standard"
+  }
+  storage_class = merge(local.storage_class_defaults, var.storage_class)
+
+  prometheus_helm_defaults = {
+    "server.persistentVolume.storageClass"       = lookup(local.storage_class, var.cloud_provider, "gp2")
+    "server.persistentVolume.size"               = "500Gi" # Without any idea of what normal is I'm just setting this as a random value
+    "server.retention"                           = "7d"
+    "alertmanager.persistentVolume.storageClass" = lookup(local.storage_class, var.cloud_provider, "gp2")
+    "alertmanager.persistentVolume.size"         = "100Gi"
+  }
+  prometheus_helm_settings = merge(local.prometheus_helm_defaults, var.prometheus_helm_settings)
+
+}

--- a/helm/prometheus/locals.tf
+++ b/helm/prometheus/locals.tf
@@ -9,7 +9,7 @@ locals {
 
   prometheus_helm_defaults = {
     "server.persistentVolume.storageClass"       = lookup(local.storage_class, var.cloud_provider, "gp2")
-    "server.persistentVolume.size"               = "500Gi" # Without any idea of what normal is I'm just setting this as a random value
+    "server.persistentVolume.size"               = "500Gi"
     "server.retention"                           = "7d"
     "alertmanager.persistentVolume.storageClass" = lookup(local.storage_class, var.cloud_provider, "gp2")
     "alertmanager.persistentVolume.size"         = "100Gi"

--- a/helm/prometheus/main.tf
+++ b/helm/prometheus/main.tf
@@ -1,0 +1,29 @@
+
+resource "kubernetes_namespace" "monitoring" {
+  count = var.enabled && var.create_namespace ? 1 : 0
+  metadata {
+    name = var.namespace
+
+    labels = {
+      app = "prometheus"
+    }
+  }
+}
+
+resource "helm_release" "prometheus" {
+  count      = var.enabled ? 1 : 0
+  name       = "prometheus"
+  repository = local.helm_stable_repository
+  chart      = "prometheus"
+  namespace  = var.namespace
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.prometheus_helm_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+}

--- a/helm/prometheus/variables.tf
+++ b/helm/prometheus/variables.tf
@@ -1,0 +1,31 @@
+variable "enabled" {
+  default = true
+}
+
+variable "create_namespace" {
+  description = "Flag to create namespace or use existing namespace"
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace to install prometheus helm chart"
+  default     = "monitoring"
+}
+
+variable "cloud_provider" {
+  description = "Cloud provider, accepted value is aws or gcp"
+  default     = "aws"
+}
+
+variable "storage_class" {
+  description = "A map of cloud provider and names of kubernetes storage classes"
+  type        = map(string)
+  default     = {}
+}
+
+variable "prometheus_helm_settings" {
+  description = "Helm prometheus settings, see https://github.com/helm/charts/tree/master/stable/prometheus for details"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Create a generic prometheus helm chart module usable by both gcp and aws.

Sneaked in a gke fix as well