### PR TITLE
[gcp][gke] Enable velero by default

### DIFF
--- a/gcp/gke/helm.tf
+++ b/gcp/gke/helm.tf
@@ -22,7 +22,12 @@ resource "helm_release" "velero" {
     }
   }
 
-  depends_on = [module.gke]
+  depends_on = [
+    module.gke,
+    module.velero_workload_identity,
+    google_storage_bucket.bucket,
+
+  ]
 }
 
 resource "helm_release" "external_secrets" {
@@ -41,5 +46,10 @@ resource "helm_release" "external_secrets" {
       value = item.value
     }
   }
+
+  depends_on = [
+    module.gke,
+    module.external-secrets-workload-identity
+  ]
 
 }


### PR DESCRIPTION
Installs velero helm charts and make this work with GKE's workload identity. The permissions and installation instructions was taken from https://github.com/vmware-tanzu/velero-plugin-for-gcp#install-and-start-velero