### PR TITLE
[aws][eks] Be more opinionated configuring Flux

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -72,6 +72,28 @@ module "eks" {
 }
 ```
 
+## Cluster Add-ons
+### FluxCD
+FluxCD can be installed into the cluster by setting the cluster feature to true:
+```
+locals {
+  cluster_features = {
+    "flux" = true
+  }
+}
+```
+Flux configuration is performed by flags, this module exposes the next flags:
+```
+flux_settings_defaults = {
+  "git.path"                  = "k8s/"
+  "syncGarbageCollection.dry" = true
+  "git.pollInterval"          = "2m"
+  "git.branch"                = "main"
+  "git.url"                   = "git@github.com:mozilla-it/${var.cluster_name}-infra"
+}
+```
+Their default values are very opinionated towards Mozilla IT-SE best practices on how to configure clusters. If you are using this module ouside of Mozilla IT you most likely want to customize `git.url`, `git.path` and `git.branch`.
+
 ## Inputs
 
 | Name                           | Description                                                                                          | Default      |

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -133,6 +133,8 @@ locals {
     "git.path"                  = "k8s/"
     "syncGarbageCollection.dry" = true
     "git.pollInterval"          = "2m"
+    "git.branch"                = "main"
+    "git.url"                   = "git@github.com:mozilla-it/${var.cluster_name}-infra"
   }
   flux_settings_expanded = merge(local.flux_settings_defaults, var.flux_settings)
 


### PR DESCRIPTION
This PR is pushing to the limits how much are we opinionated with Flux installation. Mostly because of deciding the default value that git.url has, using `mozilla-it/`.

In one side I think is a good thing because will allow us not to making errors like [this](https://github.com/mozilla-it/itse-apps-stage-1-infra/commit/0ddd4644541007869a4cf5d380ed3bd4ab48908a), also anyway others using this module would need to define the URL. This will allow to create clusters using less lines of code, and enforcing standardization.

In other side, I understand this can be too much.

So I'm interested in knowing your opinion. Happy to close this PR if we don't agree with the approach