### PR TITLE
[gcp][gke] Optional naming of kubernetes service accounts

### DIFF
--- a/gcp/gke/velero.tf
+++ b/gcp/gke/velero.tf
@@ -42,9 +42,11 @@ resource "google_storage_bucket_iam_binding" "object_admin" {
 
 module "velero_workload_identity" {
   source                 = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master"
+  enabled                = local.cluster_features["velero"]
   create_ksa             = false
   additional_permissions = false
-  name                   = "velero"
+  name                   = "velero-${module.gke.name}"
+  ksa_name               = "velero"
   namespace              = "velero"
   gke_cluster            = module.gke.name
   project_id             = var.project_id

--- a/gcp/identity/main.tf
+++ b/gcp/identity/main.tf
@@ -1,12 +1,17 @@
 locals {
 
+  # Sort of a hack, sometimes ksa and gsa are not the same, but we only reach have this scenario
+  # when we don't use this module to create the ksa. If we don't use this module to create the ksa
+  # then we should provide our own ksa name
+  ksa_name = var.create_ksa ? var.name : var.ksa_name
+
   # Shamelessly stolen from https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/7.1.0/submodules/workload-identity
-  k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.name}]"
+  k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.ksa_name}]"
   gsa_email               = var.enabled ? google_service_account.gsa[0].email : ""
   gsa_fqdn                = var.enabled ? "serviceAccount:${google_service_account.gsa[0].email}" : null
 
   # This will cause terraform to block returning outputs until the service account is created
-  output_k8s_name      = var.create_ksa ? kubernetes_service_account.ksa[0].metadata[0].name : var.name
+  output_k8s_name      = var.create_ksa ? kubernetes_service_account.ksa[0].metadata[0].name : local.ksa_name
   output_k8s_namespace = var.create_ksa ? kubernetes_service_account.ksa[0].metadata[0].namespace : var.namespace
 }
 

--- a/gcp/identity/variables.tf
+++ b/gcp/identity/variables.tf
@@ -1,6 +1,8 @@
 variable "project_id" {}
 
-variable "name" {}
+variable "name" {
+  description = "Name of the google service account to create, optionally if `var.create_ksa` is set to `true` then the ksa will be the same as the gsa"
+}
 
 variable "gke_cluster" {}
 
@@ -24,4 +26,9 @@ variable "additional_permissions" {
   description = "Option to add additonal `secretmanager.secretAccessor` and `logging.logWriter` permission to SA"
   type        = bool
   default     = true
+}
+
+variable "ksa_name" {
+  description = "Name of kubernetes service account, only configure this value if `var.create_ksa` is set to false"
+  default     = ""
 }


### PR DESCRIPTION
Since we enabled optional creation of kubernetes service accounts (ksa) we shouldn't assume that the name of the ksa will be same as the gsa. This adds an argument for `ksa_name` which allows you to set the `ksa_name` only if you tell the module to not create the ksa