### PR TITLE
[gcp] Add random string suffix at end of the gsa

### DIFF
--- a/gcp/gke/external_secrets.tf
+++ b/gcp/gke/external_secrets.tf
@@ -1,10 +1,18 @@
 
+resource "random_string" "external_secrets_suffix" {
+  length  = 4
+  lower   = true
+  number  = false
+  upper   = false
+  special = false
+}
+
 module "external-secrets-workload-identity" {
   source      = "github.com/mozilla-it/terraform-modules//gcp/identity?ref=master"
   enabled     = local.cluster_features["external_secrets"]
-  create_ksa  = false # Allow chart to create
-  name        = "kubernetes-external-secrets-${module.gke.name}"
-  ksa_name    = "kubernetes-external-secrets" # If this value changes make sure local.tf value changes too
+  create_ksa  = false                                                              # Allow chart to create
+  name        = "external-secrets-${random_string.external_secrets_suffix.result}" # Select hash to randomize name
+  ksa_name    = "kubernetes-external-secrets"                                      # If this value changes make sure local.tf value changes too
   namespace   = "kube-system"
   gke_cluster = module.gke.name
   project_id  = var.project_id

--- a/gcp/gke/locals.tf
+++ b/gcp/gke/locals.tf
@@ -49,7 +49,7 @@ locals {
     "securityContext.fsGroup"                                       = "65534"
     "env.POLLER_INTERVAL_MILLISECONDS"                              = "300000"
     "serviceAccount.name"                                           = "kubernetes-external-secrets"
-    "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account" = "kubernetes-external-secrets@${var.project_id}.iam.gserviceaccount.com"
+    "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account" = module.external-secrets-workload-identity.gcp_service_account_email
 
   }
   external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)

--- a/gcp/identity/main.tf
+++ b/gcp/identity/main.tf
@@ -16,10 +16,11 @@ locals {
 }
 
 resource "google_service_account" "gsa" {
-  count      = var.enabled ? 1 : 0
-  account_id = var.name
-  project    = var.project_id
-  provider   = google-beta
+  count        = var.enabled ? 1 : 0
+  account_id   = var.name
+  display_name = substr("gsa bound to ksa for cluster ${var.gke_cluster}", 0, 100)
+  project      = var.project_id
+  provider     = google-beta
 }
 
 # NOTE: Consider moving this outside of this module?


### PR DESCRIPTION
Adds a random string suffix for `external-secrets` helm chart

Modified identity module to also have a display name for each gsa that is created