### PR TITLE
Add service account name for flux module

### DIFF
--- a/gcp/gke/locals.tf
+++ b/gcp/gke/locals.tf
@@ -56,6 +56,7 @@ locals {
 
   flux_defaults = {
     "git.path"                                                      = "k8s/"
+    "serviceAccount.name"                                           = "flux"
     "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account" = module.flux-workload-identity.gcp_service_account_email
   }
   flux_settings = merge(local.flux_defaults, var.flux_settings)


### PR DESCRIPTION
The GKE module references the service account for flux so it fails if we do not add `serviceAccount.name` in the locals portion