### PR TITLE
Remove stable repository

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -5,7 +5,6 @@ by default, packages installed listed below:
  - `aws-node-termination-handler` - Drains node when a node is terminated
  - `metrics-server` - metrics server we all know and love
  - `cluster-autoscaler` - Cluster autoscaler
- - `reloader` - Reloads a deployment when you update a configmap or secret
  - `flux` - This is an optional package and installs the flux package
  - `helm-operator` - This is an optional package and installs the flux helm operator
  - `kubernetes-external-secrets` - This is an optional package for transforming ASM secrets into Kubernetes secrets
@@ -75,8 +74,8 @@ module "eks" {
 ## Cluster Add-ons
 ### Kubernetes External Secrets
 [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) allows mapping secrets stored in AWS Secrets Manager to Kubernetes secrets.
- 
-In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_settings.secrets_path` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions. 
+
+In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_settings.secrets_path` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions.
 
 For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `secrets_paths` variable should be set to `secrets_path = "/stage/*"`.
 
@@ -100,7 +99,6 @@ If not set, this will take the default value `*` which will allow kubernetes-ext
 | `enable_logging`               | Enable kubernetes cluster logging                                                                    | `false`      |
 | `enable_velero`                | Creates bucket and sets up velero app on cluster                                                     | `true`       |
 | `cluster_autoscaler_settings`  | Map to customize or override default helm chart values for cluster autoscaler                        | `{}`         |
-| `reloader_settings`            | Map to customize or override default helm chart values for reloader                                  | `{}`         |
 | `velero_settings`              | Map to customize or override default helm chart values for velero                                    | `{}`         |
 | `flux_helm_operator_settings`  | Map to customize or override default helm chart values for flux helm operator                        | `{}`         |
 | `flux_settings`                | Map to customize or override default helm chart values for flux                                      | `{}          |

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -13,7 +13,6 @@ locals {
     "cluster_autoscaler" = true
     "metrics_server"     = true
     "velero"             = true
-    "reloader"           = false
     "prometheus"         = false
     "aws_calico"         = false
     "alb_ingress"        = false
@@ -27,34 +26,35 @@ locals {
 
   cluster_autoscaler_name_prefix               = "${module.eks.cluster_id}-cluster-autoscaler-${var.region}"
   cluster_autoscaler_service_account_namespace = "kube-system"
-  cluster_autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler"
+  cluster_autoscaler_service_account_name      = "cluster-autoscaler-aws-cluster-autoscaler-chart"
 
   # Maps k8s version to an image version
   cluster_autoscaler_versions = {
     "1.14" = "v1.14.8"
     "1.15" = "v1.15.6"
     "1.16" = "v1.16.5"
-    "1.17" = "v1.17.2"
-    "1.18" = "v1.18.1"
+    "1.17" = "v1.17.3"
+    "1.18" = "v1.18.2"
+    "1.19" = "v1.19.0"
   }
 
   cluster_autoscaler_defaults = {
-    "awsRegion"                                                     = var.region
-    "image.repository"                                              = "us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"
-    "image.tag"                                                     = lookup(local.cluster_autoscaler_versions, var.cluster_version)
-    "autoDiscovery.clusterName"                                     = module.eks.cluster_id
-    "autoDiscovery.enabled"                                         = "true"
-    "rbac.create"                                                   = "true"
-    "rbac.serviceAccountAnnotations.eks\\.amazonaws\\.com/role-arn" = module.cluster_autoscaler_role.this_iam_role_arn
-    "extraArgs.skip-nodes-with-system-pods"                         = "false"
-    "extraArgs.balance-similar-node-groups"                         = "true"
+    "awsRegion"                                                      = var.region
+    "image.repository"                                               = "us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler"
+    "image.tag"                                                      = lookup(local.cluster_autoscaler_versions, var.cluster_version)
+    "autoDiscovery.clusterName"                                      = module.eks.cluster_id
+    "autoDiscovery.enabled"                                          = "true"
+    "rbac.create"                                                    = "true"
+    "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.cluster_autoscaler_role.this_iam_role_arn
+    "extraArgs.skip-nodes-with-system-pods"                          = "false"
+    "extraArgs.balance-similar-node-groups"                          = "true"
   }
   cluster_autoscaler_settings = merge(local.cluster_autoscaler_defaults, var.cluster_autoscaler_settings)
 
-  reloader_defaults = {
-    "reloader.deployment.image.tag" = "v0.0.65"
+  metrics_server_defaults = {
+    "apiService.create" = true
   }
-  reloader_settings = merge(local.reloader_defaults, var.reloader_settings)
+  metrics_server_settings = merge(local.metrics_server_defaults, var.metrics_server_settings)
 
   # Settings taken from
   # https://github.com/vmware-tanzu/helm-charts/tree/master/charts/velero

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -92,8 +92,8 @@ variable "cluster_autoscaler_settings" {
   default     = {}
 }
 
-variable "reloader_settings" {
-  description = "Customize reloader helm chart"
+variable "metrics_server_settings" {
+  description = "Metrics server settings"
   type        = map(string)
   default     = {}
 }

--- a/helm/prometheus/locals.tf
+++ b/helm/prometheus/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  helm_stable_repository = "https://kubernetes-charts.storage.googleapis.com"
+  helm_stable_repository     = "https://kubernetes-charts.storage.googleapis.com"
+  helm_prometheus_repository = "https://prometheus-community.github.io/helm-charts"
 
   storage_class_defaults = {
     "aws" = "gp2"


### PR DESCRIPTION
The stable repo has been deprecated see (https://github.com/helm/charts#deprecation-timeline)

So this is an attempt to move away from using helm charts hosted on this the stable repo

Moving existing charts from stable to its respective repos can cause terraform to complain so if it fails your best bet is to run a `terraform taint` against the `helm_release` resource