### PR TITLE
[aws][eks] Fix default path for external secrets

### DIFF
--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -106,7 +106,7 @@ locals {
     "securityContext.fsGroup"                                   = "65534"
     "serviceAccount.name"                                       = "kubernetes-external-secrets"
     "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.external_secrets.this_iam_role_arn
-    "secrets_path"                                              = "/*"
+    "secrets_path"                                              = "*"
   }
   external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)
 


### PR DESCRIPTION
The path `/*` would only be valid for secrets starting with `//`