### PR TITLE
Rename cluster-autoscaler chart

### DIFF
--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -42,7 +42,7 @@ resource "helm_release" "cluster_autoscaler" {
   count      = var.create_eks && local.cluster_features["cluster_autoscaler"] ? 1 : 0
   name       = "cluster-autoscaler"
   repository = local.helm_autoscaler_repository
-  chart      = "cluster-autoscaler-chart"
+  chart      = "cluster-autoscaler"
   namespace  = "kube-system"
 
   dynamic "set" {


### PR DESCRIPTION
Based on README from the k8s helm chart it is now safe to rename the chart

https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler#migration-from-1x-to-9x-versions-of-this-chart