### PR TITLE
Remove load_config_file option

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -3,7 +3,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 provider "helm" {
@@ -11,7 +10,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster.token
-    load_config_file       = false
   }
 }
 

--- a/aws/eks/versions.tf
+++ b/aws/eks/versions.tf
@@ -1,3 +1,18 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~>2"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~>2"
+    }
+  }
 }


### PR DESCRIPTION
As of version 2.0 of the `kubernetes` and `helm` provider the `load_config_file` option is no longer supported