### PR TITLE
RDS: Default to 30 days of backups

### DIFF
--- a/aws/database/variables.tf
+++ b/aws/database/variables.tf
@@ -95,7 +95,7 @@ variable "parameter_group_name" {
 }
 
 variable "backup_retention_period" {
-  default = 0
+  default = 30
 }
 
 variable "replica_enabled" {


### PR DESCRIPTION
Services and Data SRE have previously agreed to secops request to retain
DB backups for 30 days. We should do the same.

We can override this for nonprod environments.