### PR TITLE
Adding support for influxdb

### DIFF
--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -157,6 +157,13 @@ resource "helm_release" "kubernetes_external_secrets" {
   }
 }
 
+module "configmapsecrets" {
+  source                         = "github.com/mozilla-it/terraform-modules//helm/configmapsecrets?ref=master"
+  enabled                        = local.cluster_features["configmapsecrets"]
+  configmapsecrets_helm_settings = var.configmapsecrets_settings
+}
+
+
 resource "helm_release" "fluentd_papertrail" {
   count      = var.create_eks && local.cluster_features["fluentd_papertrail"] && local.cluster_features["external_secrets"] ? 1 : 0
   name       = "fluentd-papertrail"
@@ -179,3 +186,4 @@ resource "helm_release" "fluentd_papertrail" {
     }
   }
 }
+

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -158,7 +158,7 @@ resource "helm_release" "kubernetes_external_secrets" {
 }
 
 module "configmapsecrets" {
-  source                         = "github.com/mozilla-it/terraform-modules//helm/configmapsecrets?ref=master"
+  source                         = "../../helm/configmapsecrets/"
   enabled                        = local.cluster_features["configmapsecrets"]
   configmapsecrets_helm_settings = var.configmapsecrets_settings
 }

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -158,8 +158,8 @@ resource "helm_release" "kubernetes_external_secrets" {
 }
 
 module "configmapsecrets" {
+  count = local.cluster_features["configmapsecrets"] ? 1 : 0
   source                         = "../../helm/configmapsecrets/"
-  enabled                        = local.cluster_features["configmapsecrets"]
   configmapsecrets_helm_settings = var.configmapsecrets_settings
 }
 

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -158,7 +158,7 @@ resource "helm_release" "kubernetes_external_secrets" {
 }
 
 module "configmapsecrets" {
-  count = local.cluster_features["configmapsecrets"] ? 1 : 0
+  count                          = local.cluster_features["configmapsecrets"] ? 1 : 0
   source                         = "../../helm/configmapsecrets/"
   configmapsecrets_helm_settings = var.configmapsecrets_settings
 }

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -15,7 +15,7 @@ locals {
     "metrics_server"     = true
     "velero"             = true
     "external_secrets"   = true
-    "configmapsecrets"   = true
+    "configmapsecrets"   = false
     "fluentd_papertrail" = false # discuss
     "prometheus"         = false
     "aws_calico"         = false

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -9,11 +9,13 @@ locals {
     var.tags,
   )
 
+
   cluster_features_defaults = {
     "cluster_autoscaler" = true
     "metrics_server"     = true
     "velero"             = true
     "external_secrets"   = true
+    "configmapsecrets"   = true
     "fluentd_papertrail" = false # discuss
     "prometheus"         = false
     "aws_calico"         = false
@@ -21,6 +23,8 @@ locals {
     "flux"               = false
     "flux_helm_operator" = false
   }
+
+
   cluster_features = merge(local.cluster_features_defaults, var.cluster_features)
 
   cluster_log_type = var.enable_logging ? ["api", "audit", "authenticator", "controllerManager", "scheduler"] : []
@@ -144,5 +148,12 @@ locals {
     "secrets.name"               = "fluentd-papertrail"
   }
   fluentd_papertrail_settings = merge(local.fluentd_papertrail_defaults, var.fluentd_papertrail_settings)
+
+  prometheus_customization_defaults = {
+    "influxdb.enabled" = "True"
+    "prom.clustername" = module.eks.cluster_id
+  }
+
+  prometheus_customization_settings = merge(local.prometheus_customization_defaults, var.prometheus_customization_settings)
 
 }

--- a/aws/eks/monitoring.tf
+++ b/aws/eks/monitoring.tf
@@ -1,7 +1,27 @@
-
 module "prometheus" {
   source                   = "github.com/mozilla-it/terraform-modules//helm/prometheus?ref=master"
   enabled                  = local.cluster_features["prometheus"]
   cloud_provider           = "aws"
   prometheus_helm_settings = var.prometheus_settings
+  influxdb                 = var.influxdb
 }
+
+resource "helm_release" "prometheus_customizations" {
+  # only checking dependencies here, not features.  So maybe these customizations can be used in a modular way going forward.
+  count      = local.cluster_features["prometheus"] && local.cluster_features["external_secrets"] && local.cluster_features["configmapsecrets"] ? 1 : 0
+  name       = "prometheus-customizations"
+  repository = local.helm_mozilla_repository
+  chart      = "prometheus-customizations"
+  namespace  = module.prometheus.namespace
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.prometheus_customization_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+}
+

--- a/aws/eks/monitoring.tf
+++ b/aws/eks/monitoring.tf
@@ -1,5 +1,5 @@
 module "prometheus" {
-  source                   = "github.com/mozilla-it/terraform-modules//helm/prometheus?ref=master"
+  source                   = "../../helm/prometheus"
   enabled                  = local.cluster_features["prometheus"]
   cloud_provider           = "aws"
   prometheus_helm_settings = var.prometheus_settings

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -135,6 +135,18 @@ variable "prometheus_settings" {
   default     = {}
 }
 
+variable "prometheus_customization_settings" {
+  description = "Customized or override prometheus helm chart values"
+  type        = map(string)
+  default     = {}
+}
+
+variable "configmapsecrets_settings" {
+  description = "Customized or override configmapsecrets helm chart values"
+  type        = map(string)
+  default     = {}
+}
+
 variable "external_secrets_settings" {
   description = "Customize or override kubernetes_external_secrets helm chart values"
   type        = map(string)
@@ -151,4 +163,10 @@ variable "admin_users_arn" {
   description = "List of ARNs to be mapped as a cluster global admins"
   type        = list(any)
   default     = []
+}
+
+variable "influxdb" {
+  description = "A switch to set the default settings for influx"
+  type        = bool
+  default     = false
 }

--- a/helm/configmapsecrets/README.md
+++ b/helm/configmapsecrets/README.md
@@ -1,0 +1,12 @@
+# Configmapsecrets module
+Installs configmapsecrets via a helm chart
+
+## Usage
+
+```hcl
+module "configmapssecret" {
+  source         = "github.com/mozilla-it/terraform-modules//helm/configmapsecrets?ref=master
+  enabled        = true
+}
+```
+

--- a/helm/configmapsecrets/locals.tf
+++ b/helm/configmapsecrets/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  helm_configmapsecrets_repository = "https://mozilla-it.github.io/helm-charts"
+
+
+  configmapsecrets_helm_defaults = {
+
+  }
+  configmapsecrets_helm_settings = merge(local.configmapsecrets_helm_defaults, var.configmapsecrets_helm_settings)
+
+}

--- a/helm/configmapsecrets/main.tf
+++ b/helm/configmapsecrets/main.tf
@@ -1,6 +1,6 @@
 
 resource "kubernetes_namespace" "configmapsecrets" {
-  count = var.enabled && var.create_namespace ? 1 : 0
+  count = var.create_namespace ? 1 : 0
   metadata {
     name = var.namespace
 
@@ -11,7 +11,6 @@ resource "kubernetes_namespace" "configmapsecrets" {
 }
 
 resource "helm_release" "configmapsecrets" {
-  count      = var.enabled ? 1 : 0
   name       = "configmapsecrets"
   repository = local.helm_configmapsecrets_repository
   chart      = "configmapsecrets"

--- a/helm/configmapsecrets/main.tf
+++ b/helm/configmapsecrets/main.tf
@@ -1,0 +1,29 @@
+
+resource "kubernetes_namespace" "configmapsecrets" {
+  count = var.enabled && var.create_namespace ? 1 : 0
+  metadata {
+    name = var.namespace
+
+    labels = {
+      app = "configmapsecrets"
+    }
+  }
+}
+
+resource "helm_release" "configmapsecrets" {
+  count      = var.enabled ? 1 : 0
+  name       = "configmapsecrets"
+  repository = local.helm_configmapsecrets_repository
+  chart      = "configmapsecrets"
+  namespace  = var.namespace
+
+  dynamic "set" {
+    iterator = item
+    for_each = local.configmapsecrets_helm_settings
+
+    content {
+      name  = item.key
+      value = item.value
+    }
+  }
+}

--- a/helm/configmapsecrets/variables.tf
+++ b/helm/configmapsecrets/variables.tf
@@ -1,6 +1,4 @@
-variable "enabled" {
-  default = true
-}
+
 
 variable "create_namespace" {
   description = "Flag to create namespace or use existing namespace"

--- a/helm/configmapsecrets/variables.tf
+++ b/helm/configmapsecrets/variables.tf
@@ -1,0 +1,20 @@
+variable "enabled" {
+  default = true
+}
+
+variable "create_namespace" {
+  description = "Flag to create namespace or use existing namespace"
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace to install configmapsecrets helm chart"
+  default     = "configmapsecrets"
+}
+
+variable "configmapsecrets_helm_settings" {
+  description = "Helm configmapsecrets settings, we are custom building the helm chart. see https://github.com/mozilla-it/helm-charts/blob/main/charts/configmapsecrets/values.yaml for details"
+  type        = map(string)
+  default     = {}
+}

--- a/helm/prometheus/locals.tf
+++ b/helm/prometheus/locals.tf
@@ -8,12 +8,29 @@ locals {
   storage_class = merge(local.storage_class_defaults, var.storage_class)
 
   prometheus_helm_defaults = {
-    "server.persistentVolume.storageClass"       = lookup(local.storage_class, var.cloud_provider, "gp2")
-    "server.persistentVolume.size"               = "20Gi"
-    "server.retention"                           = "7d"
-    "alertmanager.persistentVolume.storageClass" = lookup(local.storage_class, var.cloud_provider, "gp2")
-    "alertmanager.persistentVolume.size"         = "5Gi"
+    "server.persistentVolume.storageClass" = lookup(local.storage_class, var.cloud_provider, "gp2")
+    "server.persistentVolume.size"         = "20Gi"
+    "server.retention"                     = "7d"
+    "alertmanager.enabled"                 = "False"
+    "grafana.enabled"                      = "False"
+    "configmapReload.prometheus.enabled"   = "False"
+    "server.statefulsetReplica.enabled"    = "True"
+    "server.statefulSet.enabled"           = "True"
+    "server.replicaCount"                  = 2
+    "server.strategy.type"                 = "Recreate"
   }
-  prometheus_helm_settings = merge(local.prometheus_helm_defaults, var.prometheus_helm_settings)
+
+  prom_influx_settings = {
+    "server.configPath"                      = "/etc/secret/prometheus.yml"
+    "server.extraSecretMounts[0].name"       = "secret-files"
+    "server.extraSecretMounts[0].mountPath"  = "/etc/secret"
+    "server.extraSecretMounts[0].subPath"    = ""
+    "server.extraSecretMounts[0].secretName" = "prometheus-config"
+    "server.extraSecretMounts[0].readOnly"   = "True"
+  }
+  # create a new dict to merge in, based on if the settings should be passed or not.
+  tmp_prom_influx_settings = var.influxdb ? local.prom_influx_settings : {}
+
+  prometheus_helm_settings = merge(local.tmp_prom_influx_settings, local.prometheus_helm_defaults, var.prometheus_helm_settings)
 
 }

--- a/helm/prometheus/main.tf
+++ b/helm/prometheus/main.tf
@@ -27,3 +27,5 @@ resource "helm_release" "prometheus" {
     }
   }
 }
+
+

--- a/helm/prometheus/outputs.tf
+++ b/helm/prometheus/outputs.tf
@@ -1,0 +1,3 @@
+output "namespace" {
+  value = var.namespace
+}

--- a/helm/prometheus/variables.tf
+++ b/helm/prometheus/variables.tf
@@ -29,3 +29,9 @@ variable "prometheus_helm_settings" {
   type        = map(string)
   default     = {}
 }
+
+variable "influxdb" {
+  description = "A switch to set the default settings for influx"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Making it possible to deploy a helm chart that configures influxdb as a remote write.
uses configmapsecrets and external secrets, so deploy those as well.
But only if people want, attempting to make this opt in as much as possible, but easy to opt into.