### PR TITLE
explicitly pin latest vesrion for autoscaler helm_release

### DIFF
--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -44,6 +44,7 @@ resource "helm_release" "cluster_autoscaler" {
   repository = local.helm_autoscaler_repository
   chart      = "cluster-autoscaler"
   namespace  = "kube-system"
+  version    = "9.9.2"
 
   dynamic "set" {
     iterator = item


### PR DESCRIPTION
Jira ticket: https://jira.mozilla.com/browse/SE-1919

What this PR does: Pin the version field for the cluster-autoscaler helm_release. This came up in the context up updating the K8s version for the itse-apps-prod-1 cluster, which currently doesn't update this particular helm_release yet (it ignores the default, which is to get the latest version, and returns version 1.1.0, which no longer exists).