### PR TITLE
Adding an optional kubernetes permission object

### DIFF
--- a/aws/eks/k8s_rbac.tf
+++ b/aws/eks/k8s_rbac.tf
@@ -1,0 +1,18 @@
+resource "kubernetes_cluster_role_binding" "view-rolebinding" {
+  count = local.cluster_features["k8s_rbac_view"] ? 1 : 0
+
+  metadata {
+    name = "view-access-binding"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "view"
+  }
+  subject {
+    kind      = "Group"
+    name      = "view-access-group"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+}

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -22,6 +22,7 @@ locals {
     "alb_ingress"        = false
     "flux"               = false
     "flux_helm_operator" = false
+    "k8s_rbac_view"      = false
   }
 
 


### PR DESCRIPTION
This will be readonly/view.
It was easiest to add here because the kube perms don't correctly get exposed by the eks module.
Choose to keep this at the same level as other features to keep the code simple.
This assumes we won't have that many rbac objects to create, it'll be a pain to manage if we get to 10 for example.=