### PR TITLE
make secrets_path for external_secrets in eks module an array

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -73,9 +73,9 @@ module "eks" {
 ### Kubernetes External Secrets
 [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) allows mapping secrets stored in AWS Secrets Manager to Kubernetes secrets.
 
-In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_settings.secrets_path` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions.
+In order to allow the process to fetch secrets from the cloud secret store, the variable `external_secrets_paths` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions.
 
-For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `secrets_paths` variable should be set to `secrets_path = "/stage/*"`.
+For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `external_secrets_paths` variable should be set to `external_secrets_paths = ["/stage/*"]`.
 
 If not set, this will take the default value `*` which will allow kubernetes-external-secrets fetch all secrets in the cluster region.
 

--- a/aws/eks/external_secrets.tf
+++ b/aws/eks/external_secrets.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "external_secrets" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${local.external_secrets_settings["secrets_path"]}"
+      for secrets_path in var.external_secrets_paths :
+      "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${secrets_path}"
     ]
   }
 

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -111,7 +111,6 @@ locals {
     "securityContext.fsGroup"                                   = "65534"
     "serviceAccount.name"                                       = "kubernetes-external-secrets"
     "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.external_secrets.this_iam_role_arn
-    "secrets_path"                                              = "*"
   }
   external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)
 

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -153,6 +153,12 @@ variable "external_secrets_settings" {
   default     = {}
 }
 
+variable "external_secrets_paths" {
+  description = "External Secrets paths (in AWS or GCP)"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "fluentd_papertrail_settings" {
   description = "Customize fluentd papertrail helm chart"
   type        = map(string)


### PR DESCRIPTION
Jira ticket: https://mozilla-hub.atlassian.net/browse/SE-2169

What this PR does:
* makes secrets_path variable in external_secrets config block an array, so you can specific multiple secrets_paths for external_Secrets permissions on the cluster (e.g. "/dev/*" & "/stage/*" for a stage cluster that manages both)