### PR TITLE
make external_secrets_settings map(any), check for secrets_path type & force into array for role, drop that key for helm chart

### DIFF
--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -73,13 +73,11 @@ module "eks" {
 ### Kubernetes External Secrets
 [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) allows mapping secrets stored in AWS Secrets Manager to Kubernetes secrets.
 
-In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_prefixes` has to have a list of prefix values where your secrets are stored. This value is then used to create a IAM role with the right permissions.
+In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_settings.secrets_path` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions.
 
-For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `external_secrets_prefixes` variable should be set to `["/stage/*"]`.
+For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `secrets_paths` variable should be set to `secrets_path = "/stage/*"`. If you require multiple paths, you can use an array like so: `secrets_paths = ["/stage/*", "/prod/*"]`.
 
 If not set, this will take the default value `*` which will allow kubernetes-external-secrets fetch all secrets in the cluster region.
-
-*Formerly, this variable was a string value in `external_secrets_settings.secrets_path`, but that argument has been deprecated.*
 
 ## Inputs
 

--- a/aws/eks/README.md
+++ b/aws/eks/README.md
@@ -73,11 +73,13 @@ module "eks" {
 ### Kubernetes External Secrets
 [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) allows mapping secrets stored in AWS Secrets Manager to Kubernetes secrets.
 
-In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_settings.secrets_path` has to have a prefix value where your secrets are stored. This value is then used to create a IAM role with the right permissions.
+In order to allow the process to fetch secrets from the cloud secret store, the setting `external_secrets_prefixes` has to have a list of prefix values where your secrets are stored. This value is then used to create a IAM role with the right permissions.
 
-For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `secrets_paths` variable should be set to `secrets_path = "/stage/*"`.
+For example when deploying a cluster for a stage environment, it's a good practice to namespace all the secrets used by the applications in that environment with `/stage/`, so an application could store its secrets in `/stage/my-application/secrets`. In this case the `external_secrets_prefixes` variable should be set to `["/stage/*"]`.
 
 If not set, this will take the default value `*` which will allow kubernetes-external-secrets fetch all secrets in the cluster region.
+
+*Formerly, this variable was a string value in `external_secrets_settings.secrets_path`, but that argument has been deprecated.*
 
 ## Inputs
 

--- a/aws/eks/external_secrets.tf
+++ b/aws/eks/external_secrets.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "external_secrets" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${local.external_secrets_settings["secrets_path"]}"
+      for secrets_prefix in local.external_secrets_prefixes :
+      "arn:aws:secretsmanager:${var.region}:${data.aws_caller_identity.current.account_id}:secret:${secrets_prefix}"
     ]
   }
 

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -149,14 +149,14 @@ resource "helm_release" "kubernetes_external_secrets" {
 
   dynamic "set" {
     iterator = item
-    for_each = local.external_secrets_settings
+    for_each = {
+      for key, value in local.external_secrets_settings :
+      key => value if key != "secrets_path"
+    }
 
     content {
-      name = item.key
-      value = try(
-        tostring(join(", ", item.value)),
-        tostring(item.value),
-      )
+      name  = item.key
+      value = item.value
     }
   }
 }

--- a/aws/eks/helm.tf
+++ b/aws/eks/helm.tf
@@ -152,8 +152,11 @@ resource "helm_release" "kubernetes_external_secrets" {
     for_each = local.external_secrets_settings
 
     content {
-      name  = item.key
-      value = item.value
+      name = item.key
+      value = try(
+        tostring(join(", ", item.value)),
+        tostring(item.value),
+      )
     }
   }
 }

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -111,9 +111,9 @@ locals {
     "securityContext.fsGroup"                                   = "65534"
     "serviceAccount.name"                                       = "kubernetes-external-secrets"
     "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.external_secrets.this_iam_role_arn
-    "secrets_path"                                              = "*"
   }
   external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)
+  external_secrets_prefixes = contains(keys(local.external_secrets_settings), "secrets_path") ? [local.external_secrets_settings["secrets_path"]] : var.external_secrets_prefixes
 
   node_groups_attributes = {
     k8s_labels = {

--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -111,9 +111,13 @@ locals {
     "securityContext.fsGroup"                                   = "65534"
     "serviceAccount.name"                                       = "kubernetes-external-secrets"
     "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn" = module.external_secrets.this_iam_role_arn
+    "secrets_path"                                              = "*"
   }
   external_secrets_settings = merge(local.external_secrets_defaults, var.external_secrets_settings)
-  external_secrets_prefixes = contains(keys(local.external_secrets_settings), "secrets_path") ? [local.external_secrets_settings["secrets_path"]] : var.external_secrets_prefixes
+  external_secrets_prefixes = try(
+    [tostring(local.external_secrets_settings["secrets_path"])],
+    tolist(local.external_secrets_settings["secrets_path"]),
+  )
 
   node_groups_attributes = {
     k8s_labels = {

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -153,6 +153,12 @@ variable "external_secrets_settings" {
   default     = {}
 }
 
+variable "external_secrets_prefixes" {
+  description = "Set kubernetes_external_secrets role permissions to access AWS Secrets prefixes"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "fluentd_papertrail_settings" {
   description = "Customize fluentd papertrail helm chart"
   type        = map(string)

--- a/aws/eks/variables.tf
+++ b/aws/eks/variables.tf
@@ -149,14 +149,8 @@ variable "configmapsecrets_settings" {
 
 variable "external_secrets_settings" {
   description = "Customize or override kubernetes_external_secrets helm chart values"
-  type        = map(string)
+  type        = map(any)
   default     = {}
-}
-
-variable "external_secrets_prefixes" {
-  description = "Set kubernetes_external_secrets role permissions to access AWS Secrets prefixes"
-  type        = list(string)
-  default     = ["*"]
 }
 
 variable "fluentd_papertrail_settings" {


### PR DESCRIPTION
option 0: #153 (dropped because requested backwards compatibility)
option 1: #155 (make new variable for external_secrets_prefixes as array, leave external_secrets_settings as is)
option 2: #156 (this PR - make external_secrets_settings map(any), check for secrets_path type & force into array for role, force into string for helm chart)
option 3: #157 (this PR - make external_secrets_settings map(any), check for secrets_path type & force into array for role, drop that key for helm chart)

proposed flow:

    if external_secrets_settings["secrets_path"] exists with external_secrets_settings variables passed to EKS module, it can be a string or an array.
    external_secrets_settings["secrets_path"] is forced into an array local.external_secrets_prefixes which is used for the external_secrets IAM role permissions target
    external_secrets_settings["secrets_path"] is dropped from map passed to external_secrets helm chart

This allows continued usage of secrets_paths as either string or array. secrets_path is not used by the external_secrets helm chart, so not passing that value does nothing.

this has been tested with a string passed through external_secrets_settings['secrets_paths'] and a list of strings passed, but welcome more testing.