### PR TITLE
Allowing password config settings to be sent

### DIFF
--- a/aws/rand-password/main.tf
+++ b/aws/rand-password/main.tf
@@ -9,7 +9,7 @@ locals {
     upper       = true
     min_numeric = 2
   }
-  password_config = merge(var.password_config, local.password_defaults)
+  password_config = merge(local.password_defaults, var.password_config)
 
   default_tags = {
     Environment = var.environment


### PR DESCRIPTION
There was a small bug in the password variable that prevented users from setting options.
This fix allows users of this module to set options, such as not having special characters in the password.
The maps were just in the wrong order in the merge function.