### PR TITLE
add character_set option to aws/database module

### DIFF
--- a/aws/database/main.tf
+++ b/aws/database/main.tf
@@ -89,6 +89,7 @@ resource "aws_db_instance" "default" {
   snapshot_identifier                   = var.snapshot_identifier
   allow_major_version_upgrade           = var.allow_major_version_upgrade
   auto_minor_version_upgrade            = var.allow_auto_minor_version_upgrade
+  character_set_name                    = var.character_set_name
 
   tags = merge(
     local.tags,

--- a/aws/database/variables.tf
+++ b/aws/database/variables.tf
@@ -157,3 +157,8 @@ variable "replica_allow_major_version_upgrade" {
   description = "If set to 'true', it enables engine major version upgrades for replica DB"
   default     = "false"
 }
+
+variable "character_set_name" {
+  description = "Character Set Name for the Database."
+  default     = ""
+}


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2125

What this PR includes:
* Adds character_set_name variable & option for aws_db_instance resource (see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#character_set_name)
* Default is empty string, which I believe means it gets ignored if not set (as is optional configuration for a RDS instance)
* Arose for Etherpad expectation of a `utf8mb4` character set in DB