### PR TITLE
AWS/EKS: Include papertrail region setting and lock eks version to use eks module version < 18

### DIFF
--- a/aws/eks/locals.tf
+++ b/aws/eks/locals.tf
@@ -148,6 +148,7 @@ locals {
     "externalSecrets.enabled"    = true
     "externalSecrets.provider"   = "aws"
     "externalSecrets.secretsKey" = "${module.eks.cluster_id}-papertrail"
+    "externalSecrets.region"     = "${var.region}"
     "secrets.name"               = "fluentd-papertrail"
   }
   fluentd_papertrail_settings = merge(local.fluentd_papertrail_defaults, var.fluentd_papertrail_settings)

--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -21,7 +21,7 @@ resource "aws_iam_role_policy_attachment" "ssm" {
 module "eks" {
   source                        = "terraform-aws-modules/eks/aws"
   create_eks                    = var.create_eks
-  version                       = "~> 13"
+  version                       = "~> 13, < 18.0.0"
   cluster_name                  = var.cluster_name
   cluster_version               = var.cluster_version
   cluster_enabled_log_types     = local.cluster_log_type


### PR DESCRIPTION
Include as a dependency for sumo in EU region.